### PR TITLE
Снижение потребления памяти и разделение обработки доменов

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,13 @@ WORKDIR /ui
 RUN apk add --no-cache git
 
 # Clone UI repository
-ARG BRANCH=main
-RUN git clone --depth 1 --branch ${BRANCH} https://github.com/GregoryGost/gost-rdpr-ui.git .
+ARG UI_BRANCH=main
+ARG UI_REPO_URL=https://github.com/GregoryGost/gost-rdpr-ui.git
+RUN git clone --depth 1 --branch ${UI_BRANCH} ${UI_REPO_URL} .
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+ARG PNPM_VERSION=10.33.2
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
@@ -62,7 +64,7 @@ WORKDIR /app
 COPY poetry.lock pyproject.toml LICENSE ./
 
 # Install Poetry and dependencies
-ARG POETRY_VERSION=2.3.4
+ARG POETRY_VERSION=2.4.1
 RUN pip install poetry==${POETRY_VERSION} --no-cache --root-user-action=ignore \
   && poetry config virtualenvs.in-project true \
   && poetry install --no-interaction --no-cache

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Available environment variables
 | `DB_TUNE_JOURNAL_MODE` | str | `WAL` | Write-Ahead Logging - better concurrent access |
 | `DB_TUNE_WAL_AUTOCHECKPOINT` | int | `1000` | Initiate a checkpoint approximately every 1000 WAL pages (choose experimentally: if WAL grows too quickly, decrease it; if checkpoints interfere, increase it) |
 | `DB_TUNE_SYNCHRONOUS` | str | `NORMAL` | NORMAL - A good balance of performance and reliability for most VDS applications. `FULL`` provides maximum reliability, but is more expensive in terms of I/O. |
-| `DB_BUSY_TIMEOUT` | int | `2000` | This is the timeout (in milliseconds) during which SQLite will retry acquiring a lock instead of immediately failing with a "database is locked" error. Defaults in SQLite to 0 (no wait). |
+| `DB_TUNE_TEMP_STORE` | str | `FILE` | Defines where SQLite stores temporary tables and indexes. `MEMORY` can improve performance but increases memory consumption |
+| `DB_TUNE_MMAP_SIZE` | int | `0` | Defines the maximum amount of database file memory mapping. `0` disables memory-mapped I/O. Higher values may improve read performance but increase container memory usage |
+| `DB_TUNE_CACHE_SIZE` | int | `-2048` | If the value is negative, SQLite treats it as kibibytes; `-2048` means about 2 MiB cache. Positive values are interpreted as number of database pages. Lower values reduce RAM usage; higher values may improve performance at the cost of memory |
+| `DB_TUNE_BUSY_TIMEOUT` | int | `2000` | This is the timeout (in milliseconds) during which SQLite will retry acquiring a lock instead of immediately failing with a "database is locked" error. Defaults in SQLite to 0 (no wait). |
 | `DB_POOL_SIZE` | int | `10` | The number of connections to keep open inside the connection pool |
 | `DB_POOL_RECYCLE` | int | `1500` | This setting causes the pool to recycle connections after the given number of seconds has passed |
 | `DB_POOL_TIMEOUT` | int | `30` | Number of seconds to wait before giving up on getting a connection from the pool |
@@ -89,6 +92,8 @@ Available environment variables
 | `DOMAINS_FILTERED_MIN_LEN` | int | `3` | The minimum domain length required to save it to the database. This is necessary to filter out empty domains that, for some reason, are generated in MikroTik scripts |
 | `DOMAINS_UPDATE_INTERVAL` | int | `172800` | Domain selection period. This means that if a domain has been processed, it will not be processed again until this period has passed. Specified in seconds. 172800s = 2days |
 | `DOMAINS_RESOLVE_SEMAPHORE_LIMIT` | int | `60` | Limit of concurrent domain resolving tasks |
+| `DOMAINS_RESOLVE_NEW_BATCH_SIZE` | int | `500` | Limit for sampling the number of domains that have never been processed |
+| `DOMAINS_RESOLVE_STALE_BATCH_SIZE` | int | `2000` | Limit for sampling the number of previously processed domains |
 | `DOMAINS_BLACK_LIST` | str | `None` | Domains that should not be included in the database. Comma-separated list |
 | `LISTS_UPDATE_INTERVAL_SEC` | int | `604800` | The period after which the file must be uploaded and verified again. Specified in seconds. 604800s = 7days |
 | `IP_NOT_ALLOWED` | str | `127.0.0.1, 0.0.0.0, 0.0.0.0/0, ::, ::/0` | A list of IP addresses that should not be included in the database. Comma-separated list. |

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Available environment variables
 | `DB_TABLE_PREFIX` | str | `rdpr_` | Prefix for database table names |
 | `DB_SAVE_BATCH_SIZE` | int | `1000` | The maximum number of all insert, update, and delete events in the database queue. This means we write a maximum of 1000 events to the file at a time (which can be very frequent). But you should also look at the timeout parameter |
 | `DB_SAVE_BATCH_TIMEOUT` | float | `0.5` | If we haven't accumulated a batch of the size limited by the parameter "parameter1" within the interval specified here, then we do what's already in the current batch |
-| `DB_JOURNAL_MODE` | str | `WAL` | Write-Ahead Logging - better concurrent access |
-| `DB_WAL_AUTOCHECKPOINT` | int | `1000` | Initiate a checkpoint approximately every 1000 WAL pages (choose experimentally: if WAL grows too quickly, decrease it; if checkpoints interfere, increase it) |
-| `DB_SYNCHRONOUS` | str | `NORMAL` | NORMAL - A good balance of performance and reliability for most VDS applications. `FULL`` provides maximum reliability, but is more expensive in terms of I/O. |
+| `DB_TUNE_JOURNAL_MODE` | str | `WAL` | Write-Ahead Logging - better concurrent access |
+| `DB_TUNE_WAL_AUTOCHECKPOINT` | int | `1000` | Initiate a checkpoint approximately every 1000 WAL pages (choose experimentally: if WAL grows too quickly, decrease it; if checkpoints interfere, increase it) |
+| `DB_TUNE_SYNCHRONOUS` | str | `NORMAL` | NORMAL - A good balance of performance and reliability for most VDS applications. `FULL`` provides maximum reliability, but is more expensive in terms of I/O. |
 | `DB_BUSY_TIMEOUT` | int | `2000` | This is the timeout (in milliseconds) during which SQLite will retry acquiring a lock instead of immediately failing with a "database is locked" error. Defaults in SQLite to 0 (no wait). |
 | `DB_POOL_SIZE` | int | `10` | The number of connections to keep open inside the connection pool |
 | `DB_POOL_RECYCLE` | int | `1500` | This setting causes the pool to recycle connections after the given number of seconds has passed |
@@ -237,6 +237,7 @@ Get tree all modules
 
 ```sh
 poetry show --tree
+poetry show --outdated
 ```
 
 ### TODO

--- a/cache/cache.py
+++ b/cache/cache.py
@@ -7,6 +7,7 @@ from logger.logger import logger
 
 class Jobs(StrEnum):
   LISTS_LOAD            = 'lists_load'
+  DOMAINS_RESOLVE   = 'domains_resolve' # for check job
   DOMAINS_RESOLVE_NEW   = 'domains_resolve_new'
   DOMAINS_RESOLVE_STALE = 'domains_resolve_stale'
   ROS_UPDATE            = 'ros_update'

--- a/cache/cache.py
+++ b/cache/cache.py
@@ -6,9 +6,10 @@ from typing import Any, Self
 from logger.logger import logger
 
 class Jobs(StrEnum):
-  LISTS_LOAD      = 'lists_load'
-  DOMAINS_RESOLVE = 'domains_resolve'
-  ROS_UPDATE      = 'ros_update'
+  LISTS_LOAD            = 'lists_load'
+  DOMAINS_RESOLVE_NEW   = 'domains_resolve_new'
+  DOMAINS_RESOLVE_STALE = 'domains_resolve_stale'
+  ROS_UPDATE            = 'ros_update'
 
 class Cache():
   '''

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -303,7 +303,6 @@ class DomainsResolver:
   async def domains_resolve(self: Self, job_mode: Jobs) -> None:
     logger.info(f'Domains resolve mode={job_mode} - START')
     try:
-      await jobs_cache.set(Jobs.DOMAINS_RESOLVE, True)
       await jobs_cache.set(job_mode, True)
       #
       match job_mode:

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -88,7 +88,6 @@ class DomainsResolver:
       except Exception as err:
         logger.error(f'Unexpected error in flow - Resolve domains : {err}', exc_info=True)
         await sleep(self.__task_exception_error_timeout)
-  
       finally:
         self.domains_resolve_queue.task_done()
         processed += 1

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -45,7 +45,7 @@ class DomainsResolver:
   __lookup_types: tuple[Literal[RdataType.A]] = (A, ) # (A, AAAA)
   __semaphore: Semaphore = Semaphore(settings.domains_resolve_semaphore_limit)
 
-  __http_client: AsyncClient = HttpClient().get_client('domains_resolver')
+  __http_client: AsyncClient = HttpClient.get_client('domains_resolver')
 
   domains_resolve_queue: Queue[DomainResult] = Queue(maxsize=settings.queue_max_size)
 

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -45,7 +45,7 @@ class DomainsResolver:
   __lookup_types: tuple[Literal[RdataType.A]] = (A, ) # (A, AAAA)
   __semaphore: Semaphore = Semaphore(settings.domains_resolve_semaphore_limit)
 
-  __http_client: AsyncClient = HttpClient().client
+  __http_client: AsyncClient = HttpClient().get_client('domains_resolver')
 
   domains_resolve_queue: Queue[DomainResult] = Queue(maxsize=settings.queue_max_size)
 

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -9,12 +9,11 @@ from asyncio import (
   TimeoutError,
   Semaphore
 )
-from enum import StrEnum
 from dns.resolver import Answer, NoAnswer
 from dns.asyncresolver import Resolver
 from dns.exception import DNSException
 from dns.rdata import Rdata
-from dns.rdatatype import RdataType, A, AAAA, CNAME
+from dns.rdatatype import RdataType, A, CNAME
 from dns.message import QueryMessage, make_query, from_wire
 from dns.rrset import RRset
 from itertools import product
@@ -44,11 +43,11 @@ class DomainsResolver:
   __task_exception_error_timeout: float = 10.0
 
   __lookup_types: tuple[Literal[RdataType.A]] = (A, ) # (A, AAAA)
-  __semaphore: Semaphore = Semaphore(settings.domain_resolve_semaphore_limit)
+  __semaphore: Semaphore = Semaphore(settings.domains_resolve_semaphore_limit)
 
   __http_client: AsyncClient = HttpClient().client
 
-  domains_resolve_queue: Queue = Queue(maxsize=settings.queue_max_size)
+  domains_resolve_queue: Queue[DomainResult] = Queue(maxsize=settings.queue_max_size)
 
   def __init__(self: Self) -> None:
     logger.info(f'{self.__class__.__name__} init')
@@ -56,43 +55,46 @@ class DomainsResolver:
   # Get domains from Queue
   async def __task_process_domains_resolve_from_queue(self: Self, count_all: int, log_every: int) -> None:
     logger.info('STARTING A FLOW - Resolve domains')
-    processed = 0
-    while not self.__stop_domains_resolve_event.is_set() and count_all > 0:
+    processed: int = 0
+    while not self.__stop_domains_resolve_event.is_set() and processed < count_all:
       try:
-        # queue is empty - skip
-        if self.domains_resolve_queue.empty():
-          await sleep(self.__queue_sleep_timeout)
-          continue
         domain: DomainResult = await wait_for(
           self.domains_resolve_queue.get(),
           timeout=self.__queue_get_timeout
         )
+      except TimeoutError:
+        await sleep(self.__queue_sleep_timeout)
+        continue
+      try:
         logger.debug(f'START resolving domain element {domain=}')
         # get dns servers
         dns_servers: Tuple[List[DnsServerDto], List[DnsServerDto]] = await db.get_dns_servers_for_resolve() # first default, second doh
         # cname
-        domain_cname: List[DomainsPostElementReq] = await self.__dns_cname_tasker(domain=domain, default_dns_servers=dns_servers[0], doh_dns_servers=dns_servers[1])
+        domain_cname: List[DomainsPostElementReq] = await self.__dns_cname_tasker(
+          domain=domain,
+          default_dns_servers=dns_servers[0],
+          doh_dns_servers=dns_servers[1]
+        )
         if len(domain_cname) > 0:
           logger.debug(f'{domain_cname=}')
           await db.put_add_domains_to_queue(domains=domain_cname)
         # resolve
-        await self.__dns_main_tasker(domain=domain, default_dns_servers=dns_servers[0], doh_dns_servers=dns_servers[1])
+        await self.__dns_main_tasker(
+          domain=domain,
+          default_dns_servers=dns_servers[0],
+          doh_dns_servers=dns_servers[1]
+        )
         logger.debug(f'END resolving domain element {domain=}')
-        if processed % log_every == 0 or count_all == 0:
-          logger.info(f'Domains resolved: {processed}, residue: {count_all}')
-        self.domains_resolve_queue.task_done()
-      except TimeoutError:
-        await sleep(self.__queue_sleep_timeout)
-        self.domains_resolve_queue.task_done()
-        continue
       except Exception as err:
         logger.error(f'Unexpected error in flow - Resolve domains : {err}', exc_info=True)
         await sleep(self.__task_exception_error_timeout)
-        self.domains_resolve_queue.task_done()
-        continue
+  
       finally:
+        self.domains_resolve_queue.task_done()
         processed += 1
-        count_all -= 1
+        residue: int = count_all - processed
+        if processed % log_every == 0 or residue == 0:
+          logger.info(f'Domains resolved: {processed}, residue: {residue}')
     logger.info('STOP FLOW - Resolve domains')
 
   async def __dns_main_tasker(self: Self, domain: DomainResult, default_dns_servers: List[DnsServerDto], doh_dns_servers: List[DnsServerDto]) -> None:
@@ -177,7 +179,7 @@ class DomainsResolver:
           if len(result) > 0:
             domain.append_doh_lookup(result)
         else:
-          logger.warning(f'__doh_resolver for {domain=} : {response.status_code} - {response.content.decode('utf-8')}')
+          logger.warning(f"__doh_resolver for {domain=} : {response.status_code} - {response.content.decode('utf-8')}")
       except (ConnectTimeout, ReadError, RemoteProtocolError, ConnectError) as err:
         logger.debug(f'[{err.__class__.__name__}] : __doh_resolver warning err : {err}')
       except Exception as err:
@@ -214,7 +216,7 @@ class DomainsResolver:
                     list_id=domain.list_id
                   ))
         else:
-          logger.warning(f'__cname_doh_resolver for {domain=} : {response.status_code} - {response.content.decode('utf-8')}')
+          logger.warning(f"__cname_doh_resolver for {domain=} : {response.status_code} - {response.content.decode('utf-8')}")
       except (ConnectError, ConnectTimeout, ReadError, RemoteProtocolError) as err:
         logger.debug(f'[{err.__class__.__name__}] : __cname_doh_resolver debug err : {err}')
       except Exception as err:
@@ -301,6 +303,7 @@ class DomainsResolver:
   async def domains_resolve(self: Self, job_mode: Jobs) -> None:
     logger.info(f'Domains resolve mode={job_mode} - START')
     try:
+      await jobs_cache.set(Jobs.DOMAINS_RESOLVE, True)
       await jobs_cache.set(job_mode, True)
       #
       match job_mode:
@@ -333,3 +336,4 @@ class DomainsResolver:
       logger.error(f'Try Domains resolve mode={job_mode} failed [{err.__class__.__name__}] : {err}', exc_info=True)
     finally:
       await jobs_cache.set(job_mode, False)
+      await jobs_cache.set(Jobs.DOMAINS_RESOLVE, False)

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -9,6 +9,7 @@ from asyncio import (
   TimeoutError,
   Semaphore
 )
+from enum import StrEnum
 from dns.resolver import Answer, NoAnswer
 from dns.asyncresolver import Resolver
 from dns.exception import DNSException
@@ -297,32 +298,38 @@ class DomainsResolver:
   # Job
 
   # Put domains to Queue
-  async def domains_resolve(self: Self) -> None:
-    logger.info(f'Domains resolve - START')
+  async def domains_resolve(self: Self, job_mode: Jobs) -> None:
+    logger.info(f'Domains resolve mode={job_mode} - START')
     try:
-      await jobs_cache.set(Jobs.DOMAINS_RESOLVE, True)
+      await jobs_cache.set(job_mode, True)
       #
-      domains: List[DomainResult] = await db.get_domains_for_resolve()
-      len_domains = len(domains)
-      resolve_domains_log_every = settings.resolve_domains_log_every
+      match job_mode:
+        case Jobs.DOMAINS_RESOLVE_NEW:
+          domains: List[DomainResult] = await db.get_new_domains_for_resolve()
+        case Jobs.DOMAINS_RESOLVE_STALE:
+          domains: List[DomainResult] = await db.get_stale_domains_for_resolve()
+        case _:
+          raise Exception(f'Unknown domains resolve job_mode:{job_mode}')
+      len_domains: int = len(domains)
+      resolve_domains_log_every: int = settings.resolve_domains_log_every
       log_every: int = max(1, ceil(len_domains / resolve_domains_log_every))
-      logger.info(f'Domains for resolve: {len_domains}, log_every: {log_every}')
+      logger.info(f'Domains for resolve mode={job_mode}: {len_domains}, log_every: {log_every}')
       if len_domains > 0:
         #
-        logger.debug(f'Start task ...')
+        logger.debug(f'Start task {job_mode} ...')
         self.__stop_domains_resolve_event.clear()
         create_task(
           coro=self.__task_process_domains_resolve_from_queue(count_all=len_domains, log_every=log_every),
-          name='__task_process_domains_resolve_from_queue'
+          name=f'__task_process_domains_resolve_from_queue_{job_mode}'
         )
         [await self.domains_resolve_queue.put(item=domain) for domain in domains]
         # STOP domains resolve
         await self.domains_resolve_queue.join()
         self.__stop_domains_resolve_event.set()
-        logger.info(f'Domains resolve - DONE')
+        logger.info(f'Domains resolve mode={job_mode} - DONE')
       else:
-        logger.info(f'Domains resolve - Not found domains for resolve. DONE')
+        logger.info(f'Domains resolve mode={job_mode} - Not found domains for resolve. DONE')
     except Exception as err:
-      logger.error(f'Try Domains resolve failed [{err.__class__.__name__}] : {err}', exc_info=True)
+      logger.error(f'Try Domains resolve mode={job_mode} failed [{err.__class__.__name__}] : {err}', exc_info=True)
     finally:
-      await jobs_cache.set(Jobs.DOMAINS_RESOLVE, False)
+      await jobs_cache.set(job_mode, False)

--- a/client/file_loader_client.py
+++ b/client/file_loader_client.py
@@ -14,7 +14,7 @@ class FileLoaderClient:
 
   __ips_pattern: Pattern[str] = compile(r'(\b((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(/([0-9]|[1-2][0-9]|3[0-2]))?\b)|(\b(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|::([0-9a-fA-F]{1,4}:){1,5}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,2}|::([0-9a-fA-F]{1,4}:){1,3}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,2}|::([0-9a-fA-F]{1,4}:){1,2}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:[0-9a-fA-F]{1,4}|::([0-9a-fA-F]{1,4}:){1,1}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}:[0-9a-fA-F]{1,4}|::[0-9a-fA-F]{1,4}|::(:[0-9a-fA-F]{1,4}){1,7})(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?\b)')
   __domains_pattern: Pattern[str] = compile(r'(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.){1,}(?:[a-zA-Z]{2,6}|xn--[a-z0-9]+)')
-  __client: AsyncClient = HttpClient().client
+  __client: AsyncClient = HttpClient().get_client('file_loader')
 
   def __init__(self: Self):
     logger.debug(f'{self.__class__.__name__} init ...')

--- a/client/file_loader_client.py
+++ b/client/file_loader_client.py
@@ -14,7 +14,7 @@ class FileLoaderClient:
 
   __ips_pattern: Pattern[str] = compile(r'(\b((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(/([0-9]|[1-2][0-9]|3[0-2]))?\b)|(\b(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|::([0-9a-fA-F]{1,4}:){1,5}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,2}|::([0-9a-fA-F]{1,4}:){1,3}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,2}|::([0-9a-fA-F]{1,4}:){1,2}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,4}:[0-9a-fA-F]{1,4}|::([0-9a-fA-F]{1,4}:){1,1}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}:[0-9a-fA-F]{1,4}|::[0-9a-fA-F]{1,4}|::(:[0-9a-fA-F]{1,4}){1,7})(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?\b)')
   __domains_pattern: Pattern[str] = compile(r'(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.){1,}(?:[a-zA-Z]{2,6}|xn--[a-z0-9]+)')
-  __client: AsyncClient = HttpClient().get_client('file_loader')
+  __client: AsyncClient = HttpClient.get_client('file_loader')
 
   def __init__(self: Self):
     logger.debug(f'{self.__class__.__name__} init ...')

--- a/client/file_loader_client.py
+++ b/client/file_loader_client.py
@@ -19,21 +19,12 @@ class FileLoaderClient:
   def __init__(self: Self):
     logger.debug(f'{self.__class__.__name__} init ...')
 
-  # Get HASH SHA2(256) for string or bytes
-  def __get_hash(self: Self, content: bytes | str) -> str:
-    hasher = sha256()
-    if isinstance(content, str):
-      content_bytes: bytes = content.encode('utf-8')
-    else:
-      content_bytes: bytes = content
-    hasher.update(content_bytes)
-    return hasher.hexdigest().upper()
-
   async def get_domains_from_lists(self: Self, lists: List[DomainsListDto]) -> None:
     logger.debug(f'Try download domains lists: {lists=} ...')
     try:
       for file in lists:
         found_elements: Set[str] = set()
+        hasher = sha256()
         try:
           # checking if a file exists without downloading its contents
           head_response: Response = await self.__client.head(url=file.url)
@@ -41,19 +32,26 @@ class FileLoaderClient:
             # If the file does not exist, update attempts: + 1
             file.attempts = file.attempts + 1
             continue
-          response: Response = await self.__client.get(url=file.url)
-          response.raise_for_status()
-          hash: str = self.__get_hash(content=response.content)
-          if hash == file.hash: continue # skip if hashes are equal
-          async for line in response.aiter_lines():
-            found_domains: list[str] = self.__domains_pattern.findall(line)
-            found_elements.update(found_domains)
+          #
+          async with self.__client.stream(method='GET', url=file.url) as response:
+            response.raise_for_status()
+            #
+            async for line in response.aiter_lines():
+              line_bytes: bytes = line.encode('utf-8', errors='ignore')
+              hasher.update(line_bytes)
+              hasher.update(b'\n')
+              #
+              found_domains: list[str] = self.__domains_pattern.findall(line)
+              found_elements.update(found_domains)
+          hash: str = hasher.hexdigest().upper()
+          if hash == file.hash:
+            continue
           if len(found_elements) == 0:
             file.found_elements = None
             continue
-          logger.debug(f'Domains count in file "{file.name}" found_elements count={len(found_elements)} found_elements {hash=}')
           file.hash = hash
           file.found_elements = found_elements
+          logger.debug(f'Domains count in file "{file.name}" found_elements count={len(found_elements)} found_elements {hash=}')
         except Exception as err:
           logger.error(f'Download domains lists file "{file.name}" error: [{err.__class__.__name__}] {err}')
           continue
@@ -67,6 +65,7 @@ class FileLoaderClient:
     try:
       for file in lists:
         found_elements: Set[str] = set()
+        hasher = sha256()
         try:
           # checking if a file exists without downloading its contents
           head_response: Response = await self.__client.head(url=file.url)
@@ -74,21 +73,26 @@ class FileLoaderClient:
             # If the file does not exist, update attempts: + 1
             file.attempts = file.attempts + 1
             continue
-          # If the file exists, we begin processing it line by line
-          response: Response = await self.__client.get(url=file.url)
-          response.raise_for_status()
-          hash: str = self.__get_hash(content=response.content)
-          if hash == file.hash: continue # skip if hashes are equal
-          async for line in response.aiter_lines():
-            found_ips: List[Tuple[str, str]] = [(element[0], element[6]) for element in self.__ips_pattern.findall(line)]
-            found_elements.update([entry[0] for entry in found_ips if entry[0] != None and entry[0] != '']) #ipv4
-            found_elements.update([entry[1] for entry in found_ips if entry[1] != None and entry[1] != '']) #ipv6
+          async with self.__client.stream(method='GET', url=file.url) as response:
+            response.raise_for_status()
+            #
+            async for line in response.aiter_lines():
+              line_bytes: bytes = line.encode('utf-8', errors='ignore')
+              hasher.update(line_bytes)
+              hasher.update(b'\n')
+              #
+              found_ips: List[Tuple[str, str]] = [(element[0], element[6]) for element in self.__ips_pattern.findall(line)]
+              found_elements.update([entry[0] for entry in found_ips if entry[0] != None and entry[0] != '']) #ipv4
+              found_elements.update([entry[1] for entry in found_ips if entry[1] != None and entry[1] != '']) #ipv6
+          hash: str = hasher.hexdigest().upper()
+          if hash == file.hash:
+            continue
           if len(found_elements) == 0:
             file.found_elements = None
             continue
-          logger.debug(f'Ips address count in file "{file.name}" found_elements count={len(found_elements)} found_elements {hash=}')
           file.hash = hash
           file.found_elements = found_elements
+          logger.debug(f'Ips address count in file "{file.name}" found_elements count={len(found_elements)} found_elements {hash=}')
         except Exception as err:
           logger.error(f'Download ips lists file "{file.name}" error: [{err.__class__.__name__}] {err}')
           continue

--- a/client/http_base_client.py
+++ b/client/http_base_client.py
@@ -1,6 +1,7 @@
 import logging
 from httpx import AsyncClient, Timeout, AsyncHTTPTransport, Limits
 from httpx._types import HeaderTypes
+from typing import Self
 
 from logger.logger import Logger
 from config.config import settings
@@ -12,32 +13,42 @@ class HttpClient:
     'Accept': '*/*',
     'User-Agent': f'{settings.app_title} [{settings.app_version}]'
   }
-  metrics: HttpxMetrics = HttpxMetrics()
+  __metrics: HttpxMetrics = HttpxMetrics()
+  __clients: dict[str, AsyncClient] = {}
 
-  def __init__(self) -> None:
+  def __init__(self: Self) -> None:
     logging.getLogger('httpx').setLevel(Logger.LOGGER_LEVEL[settings.httpx_log_level])
+
+  @classmethod
+  def get_client(cls: type[Self], name: str = 'default', timeout: Timeout | None = None) -> AsyncClient:
+    if name in cls.__clients:
+      return cls.__clients[name]
     # Common
-    self.limits: Limits = Limits(
+    limits: Limits = Limits(
       max_connections=settings.req_max_connections,
       max_keepalive_connections=settings.req_max_keepalive_connections
     )
-    self.timeout: Timeout = Timeout(
+    default_timeout: Timeout = Timeout(
       timeout=settings.req_timeout_default,
       connect=settings.req_timeout_connect,
       read=settings.req_timeout_read
     )
-    # Async
-    self.transport: AsyncHTTPTransport = AsyncHTTPTransport(
+    transport: AsyncHTTPTransport = AsyncHTTPTransport(
       retries=settings.req_connection_retries,
       verify=settings.req_ssl_verify
     )
-    self.client: AsyncClient = AsyncClient(
-      headers=self.headers,
-      limits=self.limits,
-      transport=self.transport,
-      timeout=self.timeout
+    client: AsyncClient = AsyncClient(
+      headers=cls.headers,
+      limits=limits,
+      transport=transport,
+      timeout=timeout or default_timeout
     )
-    self.client.event_hooks['response'] = [self.metrics.async_metric_hook]
+    client.event_hooks['response'] = [cls.__metrics.async_metric_hook]
+    cls.__clients[name] = client
+    return client
 
-  async def close(self) -> None:
-    await self.client.aclose()
+  @classmethod
+  async def close(cls: type[Self]) -> None:
+    for client in cls.__clients.values():
+      await client.aclose()
+    cls.__clients.clear()

--- a/client/http_base_client.py
+++ b/client/http_base_client.py
@@ -38,3 +38,6 @@ class HttpClient:
       timeout=self.timeout
     )
     self.client.event_hooks['response'] = [self.metrics.async_metric_hook]
+
+  async def close(self) -> None:
+    await self.client.aclose()

--- a/client/http_base_client.py
+++ b/client/http_base_client.py
@@ -16,13 +16,11 @@ class HttpClient:
   __metrics: HttpxMetrics = HttpxMetrics()
   __clients: dict[str, AsyncClient] = {}
 
-  def __init__(self: Self) -> None:
-    logging.getLogger('httpx').setLevel(Logger.LOGGER_LEVEL[settings.httpx_log_level])
-
   @classmethod
   def get_client(cls: type[Self], name: str = 'default', timeout: Timeout | None = None) -> AsyncClient:
     if name in cls.__clients:
       return cls.__clients[name]
+    logging.getLogger('httpx').setLevel(Logger.LOGGER_LEVEL[settings.httpx_log_level])
     # Common
     limits: Limits = Limits(
       max_connections=settings.req_max_connections,

--- a/client/ros_updater_client.py
+++ b/client/ros_updater_client.py
@@ -559,8 +559,6 @@ class RosClient:
   async def update(self: Self, addr_type: int | None = None) -> None:
     logger.info(f'Run update ROS configs {addr_type=}')
     try:
-      # start JOB
-      await jobs_cache.set(Jobs.ROS_UPDATE, True)
       # get all RoS configs from DB
       configs: List[RosConfigDto] = await db.get_all_configs_for_ros_update()
       logger.info(f'Configs for update: {len(configs)}')

--- a/client/ros_updater_client.py
+++ b/client/ros_updater_client.py
@@ -44,7 +44,7 @@ class RosClient:
     connect=settings.req_timeout_connect,
     read=settings.ros_rest_api_read_timeout
   )
-  __client: AsyncClient = HttpClient().get_client('ros', timeout=__timeout)
+  __client: AsyncClient = HttpClient.get_client('ros', timeout=__timeout)
   __fw_strict_addr_list_postfix: str = 'strict'
 
   def __init__(self: Self) -> None:

--- a/client/ros_updater_client.py
+++ b/client/ros_updater_client.py
@@ -28,7 +28,7 @@ class RosClient:
   '''
 
   ros_update_sleep_timeout: float = 0.1
-  update_ros_queue: Queue = Queue(maxsize=settings.queue_max_size)
+  update_ros_queue: Queue[RosConfigDto] = Queue(maxsize=settings.queue_max_size)
 
   __stop_update_ros_event: Event = Event()
   __queue_sleep_timeout: float = settings.queue_sleep_timeout
@@ -55,14 +55,14 @@ class RosClient:
     logger.info('STARTING A FLOW - Update ROS configs')
     while not self.__stop_update_ros_event.is_set():
       try:
-        # queue is empty - skip
-        if self.update_ros_queue.empty():
-          await sleep(self.__queue_sleep_timeout)
-          continue
         config: RosConfigDto = await wait_for(
           self.update_ros_queue.get(),
           timeout=self.__queue_get_timeout
         )
+      except TimeoutError:
+        await sleep(self.__queue_sleep_timeout)
+        continue
+      try:
         logger.debug(f'START update ros config {config=}')
         # check connection
         await self.__check(config=config)
@@ -201,21 +201,14 @@ class RosClient:
           #   await self.__add_to_ros(config=config, action=RosAction.ROUTING_ADD, address_list=routing_address_add, route_gateway=default_ipv6_gateway)
         #
         logger.debug(f'END update ros config element {config=}')
-        self.update_ros_queue.task_done()
-      except TimeoutError:
-        await sleep(self.__queue_sleep_timeout)
-        self.update_ros_queue.task_done()
-        continue
       except RemoteProtocolError as err:
         logger.error(f'ERROR Update ROS configs : [{err.__class__.__name__}] {err}')
         await sleep(self.__queue_sleep_timeout)
-        self.update_ros_queue.task_done()
-        continue
       except Exception as err:
         logger.error(f'Unexpected error in flow - Update ROS configs : [{err.__class__.__name__}] {err}', exc_info=True)
         await sleep(self.__task_exception_error_timeout)
+      finally:
         self.update_ros_queue.task_done()
-        continue
     logger.info('STOP FLOW - Update ROS configs')
 
   async def __check(self: Self, config: RosConfigDto) -> None:

--- a/client/ros_updater_client.py
+++ b/client/ros_updater_client.py
@@ -34,7 +34,6 @@ class RosClient:
   __queue_sleep_timeout: float = settings.queue_sleep_timeout
   __queue_get_timeout: float = settings.queue_get_timeout
   __task_exception_error_timeout: float = 10.0
-  __client: AsyncClient = HttpClient().client
   __headers: HeaderTypes = {
     'Accept': '*/*',
     'Content-Type': 'application/json',
@@ -45,10 +44,10 @@ class RosClient:
     connect=settings.req_timeout_connect,
     read=settings.ros_rest_api_read_timeout
   )
+  __client: AsyncClient = HttpClient().get_client('ros', timeout=__timeout)
   __fw_strict_addr_list_postfix: str = 'strict'
 
   def __init__(self: Self) -> None:
-    self.__client.timeout = self.__timeout
     logger.debug(f'{self.__class__.__name__} init ...')
 
   async def __task_process_update_ros_from_queue(self: Self) -> None:

--- a/config/config.py
+++ b/config/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
   domains_update_interval: int = Field(default=172800) # default 2 days
   domains_resolve_new_batch_size: int = Field(default=500)
   domains_resolve_stale_batch_size: int = Field(default=2000)
-  domain_resolve_semaphore_limit: int = Field(default=20)
+  domains_resolve_semaphore_limit: int = Field(default=20)
   domains_black_list: str = Field(default='')
   # Lists section
   lists_update_interval_sec: int = Field(default=604800) # default 7 days

--- a/config/config.py
+++ b/config/config.py
@@ -40,14 +40,17 @@ class Settings(BaseSettings):
   db_table_prefix: str = Field(default='rdpr_')
   db_save_batch_size: int = Field(default=1000) # for while task save to db
   db_save_batch_timeout: float = Field(default=5.0) # 5 sec // recomend time.monotonic()
-  db_journal_mode: str = Field(default='WAL') # Write-Ahead Logging - better concurrent access
-  db_wal_autocheckpoint: int = Field(default=1000) # Initiate a checkpoint approximately every 1000 WAL pages (choose experimentally: if WAL grows too quickly, decrease it; if checkpoints interfere, increase it)
-  db_synchronous: str = Field(default='NORMAL') # NORMAL - A good balance of performance and reliability for most VDS applications. `FULL`` provides maximum reliability, but is more expensive in terms of I/O.
-  db_busy_timeout: int = Field(default=2000) # This is the timeout (in milliseconds) during which SQLite will retry acquiring a lock instead of immediately failing with a "database is locked" error. Defaults in SQLite to 0 (no wait).
-  db_pool_size: int = Field(default=10)
+  db_pool_size: int = Field(default=5)
   db_pool_recycle: int = Field(default=1500)
   db_pool_timeout: int = Field(default=30)
-  db_pool_size_overflow: int = Field(default=2) # max 3+2=5
+  db_pool_size_overflow: int = Field(default=0) # max 3+2=5
+  db_tune_journal_mode: str = Field(default='WAL') # Write-Ahead Logging - better concurrent access
+  db_tune_wal_autocheckpoint: int = Field(default=1000) # Initiate a checkpoint approximately every 1000 WAL pages (choose experimentally: if WAL grows too quickly, decrease it; if checkpoints interfere, increase it)
+  db_tune_synchronous: str = Field(default='NORMAL') # NORMAL - A good balance of performance and reliability for most VDS applications. `FULL`` provides maximum reliability, but is more expensive in terms of I/O.
+  db_tune_busy_timeout: int = Field(default=2000) # This is the timeout (in milliseconds) during which SQLite will retry acquiring a lock instead of immediately failing with a "database is locked" error. Defaults in SQLite to 0 (no wait).
+  db_tune_temp_store: str = Field(default='FILE')
+  db_tune_mmap_size: int = Field(default=0)
+  db_tune_cache_size: int = Field(default=-2048)
   # HTTP client Requests section
   attempts_limit: int = Field(default=5) # Files download attempts limit
   httpx_log_level: str = Field(default='error')
@@ -64,7 +67,9 @@ class Settings(BaseSettings):
   # Domains section
   domains_filtered_min_len: int = Field(default=3)
   domains_update_interval: int = Field(default=172800) # default 2 days
-  domain_resolve_semaphore_limit: int = Field(default=60)
+  domains_resolve_new_batch_size: int = Field(default=500)
+  domains_resolve_stale_batch_size: int = Field(default=2000)
+  domain_resolve_semaphore_limit: int = Field(default=20)
   domains_black_list: str = Field(default='')
   # Lists section
   lists_update_interval_sec: int = Field(default=604800) # default 7 days

--- a/database/db.py
+++ b/database/db.py
@@ -1403,7 +1403,6 @@ class DataBase:
   async def lists_load(self: Self, forced: bool) -> None:
     logger.info(f'Lists load - START {forced=}')
     try:
-      await jobs_cache.set(Jobs.LISTS_LOAD, True)
       db_session: AsyncSession = await self.__read_connect()
       domains_lists_total: int = await DomainsListsDbo.get_total(db_session=db_session)
       ips_lists_total: int = await IpsListsDbo.get_total(db_session=db_session)

--- a/database/db.py
+++ b/database/db.py
@@ -165,13 +165,13 @@ class DataBase:
   async def __session_tune(self: Self, session: AsyncSession):
     # Config PRAGMA
     await session.execute(text(f'PRAGMA foreign_keys=ON')) # foreign keys support
-    await session.execute(text(f'PRAGMA temp_store = MEMORY'))
-    await session.execute(text(f'PRAGMA mmap_size = 268435456'))
-    await session.execute(text(f'PRAGMA cache_size = 10000'))
-    await session.execute(text(f'PRAGMA journal_mode={settings.db_journal_mode}'))
-    await session.execute(text(f'PRAGMA wal_autocheckpoint={settings.db_wal_autocheckpoint}'))
-    await session.execute(text(f'PRAGMA synchronous={settings.db_synchronous}'))
-    await session.execute(text(f'PRAGMA busy_timeout={settings.db_busy_timeout}'))
+    await session.execute(text(f'PRAGMA journal_mode={settings.db_tune_journal_mode}'))
+    await session.execute(text(f'PRAGMA temp_store={settings.db_tune_temp_store}'))
+    await session.execute(text(f'PRAGMA mmap_size={settings.db_tune_mmap_size}'))
+    await session.execute(text(f'PRAGMA cache_size={settings.db_tune_cache_size}'))
+    await session.execute(text(f'PRAGMA wal_autocheckpoint={settings.db_tune_wal_autocheckpoint}'))
+    await session.execute(text(f'PRAGMA synchronous={settings.db_tune_synchronous}'))
+    await session.execute(text(f'PRAGMA busy_timeout={settings.db_tune_busy_timeout}'))
     return session
 
   async def __create_tables(self: Self) -> None:
@@ -813,18 +813,37 @@ class DataBase:
     except Exception as err:
       logger.error(f'Unexpected error - Try send deleted Domains to Queue : {err}', exc_info=True)
 
-  async def get_domains_for_resolve(self: Self) -> List[DomainResult]:
-    logger.debug(f'Try get Domains for resolve ...')
+  async def get_new_domains_for_resolve(self: Self) -> List[DomainResult]:
+    logger.debug(f'Try get new domains for resolve ...')
     domains: List[DomainResult] = []
     try:
       db_session: AsyncSession = await self.__read_connect()
       # get domains for resolve
-      domains_for_resolve: Sequence[Row[Tuple[int, str, int | None, int]]] = await DomainsDbo.get_all_for_resolve(db_session=db_session)
+      domains_for_resolve: Sequence[Row[Tuple[int, str, int | None, int]]] = \
+        await DomainsDbo.get_new_for_resolve(db_session=db_session, limit=settings.domains_resolve_new_batch_size)
       domains = [DomainResult(id=domain[0], name=domain[1], list_id=domain[2]) for domain in domains_for_resolve]
-      logger.debug(f'Domains for resolve: {len(domains)}')
+      logger.debug(f'New domains for resolve: {len(domains)}')
       return domains
     except Exception as err:
-      logger.error(f'Try get Domains for resolve failed : {err}', exc_info=True)
+      logger.error(f'Try get new domains for resolve failed : {err}', exc_info=True)
+      await db_session.rollback()
+      return domains
+    finally:
+      await db_session.close()
+
+  async def get_stale_domains_for_resolve(self: Self) -> List[DomainResult]:
+    logger.debug(f'Try get stale domains for resolve ...')
+    domains: List[DomainResult] = []
+    try:
+      db_session: AsyncSession = await self.__read_connect()
+      # get domains for resolve
+      domains_for_resolve: Sequence[Row[Tuple[int, str, int | None, int]]] = \
+        await DomainsDbo.get_stale_for_resolve(db_session=db_session, limit=settings.domains_resolve_stale_batch_size)
+      domains = [DomainResult(id=domain[0], name=domain[1], list_id=domain[2]) for domain in domains_for_resolve]
+      logger.debug(f'Stale domains for resolve: {len(domains)}')
+      return domains
+    except Exception as err:
+      logger.error(f'Try get stale domains for resolve failed : {err}', exc_info=True)
       await db_session.rollback()
       return domains
     finally:
@@ -1390,7 +1409,7 @@ class DataBase:
       ips_lists_total: int = await IpsListsDbo.get_total(db_session=db_session)
       if domains_lists_total > 0:
         logger.debug(f'Load Domains lists {domains_lists_total=} ...')
-        domains_lists: List[DomainsListDto] = await DomainsListsDbo.get_for_update(db_session=db_session)
+        domains_lists: List[DomainsListDto] = await DomainsListsDbo.get_for_update(db_session=db_session, forced=forced)
         logger.debug(f'{domains_lists=}')
         await self.file_loader_client.get_domains_from_lists(lists=domains_lists)
         unactive_domains_lists: List[DomainsListDto] = [list for list in domains_lists if list.attempts >= settings.attempts_limit]
@@ -1423,7 +1442,7 @@ class DataBase:
           await self.update_domains_lists(domains_lists=active_domains_lists)
       if ips_lists_total > 0:
         logger.debug(f'Load IPs lists {ips_lists_total=} ...')
-        ips_lists: List[IpsListDto] = await IpsListsDbo.get_for_update(db_session=db_session)
+        ips_lists: List[IpsListDto] = await IpsListsDbo.get_for_update(db_session=db_session, forced=forced)
         logger.debug(f'{ips_lists=}')
         await self.file_loader_client.get_ips_from_lists(lists=ips_lists)
         unactive_ips_lists: List[IpsListDto] = [list for list in ips_lists if list.attempts >= settings.attempts_limit]

--- a/docs/OPENAPI.json
+++ b/docs/OPENAPI.json
@@ -1,0 +1,5608 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "GOST-RDPR (Resolve Domains Per Records)",
+    "summary": "A utility for working with Mikrotik RouterOS and BGP protocol for announcing IP addresses",
+    "description": "The utility provides parsing of domain names into IP addresses, processing of domain lists and their \n    subsequent parsing, processing of individual IP addresses and summarized IP groups. Updates firewall address list \n    and routing table",
+    "version": "2.0.9"
+  },
+  "paths": {
+    "/metrics": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Metrics",
+        "description": "Prometheus metrics",
+        "operationId": "Metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Welcome",
+        "description": "Base welcome answer",
+        "operationId": "Welcome__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WelcomeResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Health Check",
+        "description": "API OK checker",
+        "operationId": "Health_check_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/config": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Current Config",
+        "description": "Current config. All settings parameters",
+        "operationId": "Current_config_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dns": {
+      "get": {
+        "tags": [
+          "DNS Servers"
+        ],
+        "summary": "Get All Dns Servers Records",
+        "description": "Displays all available DNS server records. Also displays the default DNS server with ID -1",
+        "operationId": "Get_all_DNS_servers_records_dns_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "default",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "View default DNS",
+              "description": "Whether or not to include the default DNS server in the result",
+              "examples": [
+                true,
+                false
+              ]
+            },
+            "description": "Whether or not to include the default DNS server in the result"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DnsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "DNS Servers"
+        ],
+        "summary": "Add New Dns Servers",
+        "description": "Allows you to add the required DNS servers through an array with parameters",
+        "operationId": "Add_new_DNS_servers_dns_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DnsPostElementReq"
+                },
+                "examples": [
+                  [
+                    {
+                      "server": "9.9.9.9"
+                    },
+                    {
+                      "server": "1.1.1.1",
+                      "description": "Simple IPv4 DNS server"
+                    },
+                    {
+                      "doh_server": "https://dns.adguard-dns.com/dns-query",
+                      "description": "DNS over HTTPS server URL"
+                    }
+                  ]
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoDataResp"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DNS Servers"
+        ],
+        "summary": "Clear All Dns Servers Records (Warning!!!)",
+        "description": "Clear All DNS servers records. But not default record id=-1",
+        "operationId": "Clear_All_DNS_servers_records__WARNING_____dns_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/dns/search": {
+      "get": {
+        "tags": [
+          "DNS Servers"
+        ],
+        "summary": "Find Dns Server By Text",
+        "description": "Find a DNS server by text. Using fields \"server\" or \"doh_server\"",
+        "operationId": "Find_DNS_server_by_text_dns_search_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "title": "Search text",
+              "description": "Search text for fields \"server\" or \"doh_server\""
+            },
+            "description": "Search text for fields \"server\" or \"doh_server\""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DnsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dns/{id}": {
+      "get": {
+        "tags": [
+          "DNS Servers"
+        ],
+        "summary": "Get One Dns Server Record",
+        "description": "Display parameters at one DNS server record",
+        "operationId": "Get_one_DNS_server_record_dns__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": -1,
+              "title": "DNS record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DnsElementResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResp"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DNS Servers"
+        ],
+        "summary": "Delete One Dns Server Record",
+        "description": "Delete one DNS server record",
+        "operationId": "Delete_one_DNS_server_record_dns__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": -1,
+              "title": "DNS record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/domains/lists": {
+      "get": {
+        "tags": [
+          "Domains Lists"
+        ],
+        "summary": "Get All Domains Lists",
+        "description": "Displays all Domains lists records",
+        "operationId": "Get_all_Domains_lists_domains_lists_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "attempts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Attempts count",
+              "description": "Attempts count for ips list"
+            },
+            "description": "Attempts count for ips list"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainsListsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Domains Lists"
+        ],
+        "summary": "Add New Domains Lists",
+        "description": "Add new domains lists URL for download and parse for next",
+        "operationId": "Add_new_domains_lists_domains_lists_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DomainsListsPostElementReq"
+                },
+                "examples": [
+                  [
+                    {
+                      "name": "voice-domains-list",
+                      "url": "https://somedomain.som/path/path/path/voice.txt"
+                    },
+                    {
+                      "name": "voice-domains-list-2",
+                      "url": "https://somedomain.som/path/path/path/voice-2.txt",
+                      "description": "Description for some voice domains list"
+                    }
+                  ]
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoDataResp"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Domains Lists"
+        ],
+        "summary": "Delete All Domains Lists Records",
+        "description": "Delete all Domains lists records",
+        "operationId": "Delete_all_Domains_lists_records_domains_lists_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/domains/lists/search": {
+      "get": {
+        "tags": [
+          "Domains Lists"
+        ],
+        "summary": "Find Domains Lists By Text",
+        "description": "Find a Domains lists by text. Using fields \"name\" or \"url\"",
+        "operationId": "Find_Domains_lists_by_text_domains_lists_search_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "title": "Search text",
+              "description": "Search text for fields \"name\" or \"url\""
+            },
+            "description": "Search text for fields \"name\" or \"url\""
+          },
+          {
+            "name": "attempts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Attempts count",
+              "description": "Attempts count for domains list"
+            },
+            "description": "Attempts count for domains list"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainsListsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/domains/lists/{id}": {
+      "get": {
+        "tags": [
+          "Domains Lists"
+        ],
+        "summary": "Get One Domains List",
+        "description": "Displays one Domains list record info",
+        "operationId": "Get_one_Domains_list_domains_lists__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "Domains list record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainsListElementResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResp"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Domains Lists"
+        ],
+        "summary": "Delete One Domains List",
+        "description": "Delete one Domains list record",
+        "operationId": "Delete_one_Domains_list_domains_lists__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "Domains list record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/domains": {
+      "get": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Get All Domains Records",
+        "description": "Displays all available Domains records",
+        "operationId": "Get_all_Domains_records_domains_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "resolved",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "View resolved domains"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Add New Domains",
+        "description": "Background add new domains",
+        "operationId": "Add_new_domains_domains_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DomainsPostElementReq"
+                },
+                "examples": [
+                  [
+                    {
+                      "domain": "google.com"
+                    },
+                    {
+                      "domain": "rotterdam1192.discord.gg",
+                      "ros_comment": "discord domain"
+                    }
+                  ]
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoDataResp"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Clear All Domains Records (Warning!!!)",
+        "description": "Clear All Domains records. But not default record id=-1",
+        "operationId": "Clear_All_Domains_records__WARNING_____domains_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/domains/search": {
+      "get": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Find Domains By Text",
+        "description": "Find a Domains by text. Using fields \"name\" or \"url\"",
+        "operationId": "Find_Domains_by_text_domains_search_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "resolved",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "View resolved domains"
+            }
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "title": "Search text",
+              "description": "Search text for fields \"name\""
+            },
+            "description": "Search text for fields \"name\""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/domains/{id}": {
+      "get": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Get One Domain",
+        "description": "Displays one Domain record info",
+        "operationId": "Get_one_Domain_domains__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Domain record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainElementResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResp"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Delete One Domain Record",
+        "description": "Background delete one Domain record",
+        "operationId": "Delete_one_Domain_record_domains__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": -1,
+              "title": "Domain record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ips/lists": {
+      "get": {
+        "tags": [
+          "IP Address Lists"
+        ],
+        "summary": "Get All Ip Address Lists",
+        "description": "Displays all IP address lists records",
+        "operationId": "Get_all_IP_address_lists_ips_lists_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "attempts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Attempts count",
+              "description": "Attempts count for ips list"
+            },
+            "description": "Attempts count for ips list"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpsListsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "IP Address Lists"
+        ],
+        "summary": "Add New Ip Address Lists",
+        "description": "Add new IP address lists URL for download",
+        "operationId": "Add_new_IP_address_lists_ips_lists_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/IpsListsPostElementReq"
+                },
+                "examples": [
+                  [
+                    {
+                      "name": "ips-list",
+                      "url": "https://somedomain.som/path/path/path/some-ips-list"
+                    },
+                    {
+                      "name": "ips-list-2",
+                      "url": "https://somedomain.som/path/path/path/some-ips-list-2.txt",
+                      "description": "Description for some ips address list"
+                    }
+                  ]
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoDataResp"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "IP Address Lists"
+        ],
+        "summary": "Delete All Ip Address Lists Records",
+        "description": "Delete all IP address lists records",
+        "operationId": "Delete_all_IP_address_lists_records_ips_lists_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/ips/lists/search": {
+      "get": {
+        "tags": [
+          "IP Address Lists"
+        ],
+        "summary": "Find Ips Lists By Text",
+        "description": "Find a Ips lists by text. Using fields \"name\" or \"url\"",
+        "operationId": "Find_Ips_lists_by_text_ips_lists_search_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "title": "Search text",
+              "description": "Search text for fields \"name\" or \"url\""
+            },
+            "description": "Search text for fields \"name\" or \"url\""
+          },
+          {
+            "name": "attempts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Attempts count",
+              "description": "Attempts count for ips list"
+            },
+            "description": "Attempts count for ips list"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpsListsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ips/lists/{id}": {
+      "get": {
+        "tags": [
+          "IP Address Lists"
+        ],
+        "summary": "Get One Ip Address List",
+        "description": "Displays one IP address list record on ID",
+        "operationId": "Get_one_IP_address_list_ips_lists__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "Ips list record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpsListElementResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResp"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "IP Address Lists"
+        ],
+        "summary": "Delete One Ip Address List",
+        "description": "Delete one IP address list record",
+        "operationId": "Delete_one_IP_address_list_ips_lists__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "Ips list record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ips": {
+      "get": {
+        "tags": [
+          "IP address"
+        ],
+        "summary": "Get All Ip Address Records",
+        "description": "Displays all available IP address records",
+        "operationId": "Get_all_IP_address_records_ips_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "IP address type v4 or v6",
+              "description": "IP address type filter parameter",
+              "examples": [
+                4,
+                6
+              ]
+            },
+            "description": "IP address type filter parameter"
+          },
+          {
+            "name": "default_gw",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Filtered default gateway",
+              "description": "Filtered use default gateway for IP addr on clients"
+            },
+            "description": "Filtered use default gateway for IP addr on clients"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "IP address"
+        ],
+        "summary": "Add New Ip Address Records",
+        "description": "Add new IP address records. New IPs link to default domain at ID = 0",
+        "operationId": "Add_new_IP_address_records_ips_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/IpsPostElementReq"
+                },
+                "examples": [
+                  [
+                    {
+                      "addr": "1.1.1.1"
+                    },
+                    {
+                      "addr": "9.9.9.9",
+                      "domain_id": 1
+                    },
+                    {
+                      "addr": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                      "ros_comment": "discord ip address"
+                    },
+                    {
+                      "addr": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                      "domain_id": 3,
+                      "ros_comment": "meta ip address"
+                    },
+                    {
+                      "addr": "8.8.8.8",
+                      "list_id": 15,
+                      "ros_comment": "add address to list"
+                    },
+                    {
+                      "addr": "172.10.4.4",
+                      "use_default_gw": true,
+                      "ros_comment": "Exclude IP /32 from the larger mask /16/24 so it doesnt go through the VPN"
+                    }
+                  ]
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoDataResp"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "IP address"
+        ],
+        "summary": "Clear All Ip Address Records (Warning!!!)",
+        "description": "Clear All IP address records",
+        "operationId": "Clear_All_IP_address_records__WARNING_____ips_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/ips/search": {
+      "get": {
+        "tags": [
+          "IP address"
+        ],
+        "summary": "Find Ips Address By Text",
+        "description": "Find a Ips address by text. Using fields \"addr\"",
+        "operationId": "Find_Ips_address_by_text_ips_search_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "IP address type v4 or v6",
+              "description": "IP address type filter parameter",
+              "examples": [
+                4,
+                6
+              ]
+            },
+            "description": "IP address type filter parameter"
+          },
+          {
+            "name": "default_gw",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Filtered default gateway",
+              "description": "Filtered use default gateway for IP addr on clients"
+            },
+            "description": "Filtered use default gateway for IP addr on clients"
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "title": "Search text",
+              "description": "Search text for fields \"ip_address\""
+            },
+            "description": "Search text for fields \"ip_address\""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpsPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ips/{id}": {
+      "get": {
+        "tags": [
+          "IP address"
+        ],
+        "summary": "Get One Ip Address Record On Id",
+        "description": "Displays one IP address record on ID",
+        "operationId": "Get_one_IP_address_record_on_ID_ips__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "IP address record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpsElementResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResp"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ips/{id_or_ip}": {
+      "delete": {
+        "tags": [
+          "IP address"
+        ],
+        "summary": "Delete One Ip Address Record (Ip Or Id Over Query Param)",
+        "description": "Delete one IP address record on ID or IP",
+        "operationId": "Delete_one_IP_address_record__ip_or_id_over_query_param__ips__id_or_ip__delete",
+        "parameters": [
+          {
+            "name": "id_or_ip",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "title": "ID or IP address"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ros": {
+      "get": {
+        "tags": [
+          "RoS Configs"
+        ],
+        "summary": "Get All Router Os Configs",
+        "description": "Displays all Router OS configs records. No connect tests",
+        "operationId": "Get_all_Router_OS_configs_ros_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RosConfigPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "RoS Configs"
+        ],
+        "summary": "Add Router Os Configs",
+        "description": "Adds new RouterOS configurations. IP address rollout will be applied to each configuration",
+        "operationId": "Add_Router_OS_configs_ros_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RosConfigsPostElementReq"
+                },
+                "examples": [
+                  [
+                    {
+                      "host": "192.168.200.1",
+                      "user": "test",
+                      "user_password": "1234",
+                      "bgp_list_name": "bgp-networks",
+                      "description": "Test CHR Host"
+                    }
+                  ]
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoDataResp"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RoS Configs"
+        ],
+        "summary": "Delete All Routeros Configs",
+        "description": "Delete all RouterOS configs records",
+        "operationId": "Delete_all_RouterOS_configs_ros_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/ros/search": {
+      "get": {
+        "tags": [
+          "RoS Configs"
+        ],
+        "summary": "Find Router Os Configs By Text",
+        "description": "Find a Router OS configs by text. Using fields \"host\" or \"user\" or \"bgp_list_name\"",
+        "operationId": "Find_Router_OS_configs_by_text_ros_search_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "exclusiveMinimum": 0,
+              "title": "Limit param",
+              "description": "Number of items to be sampled",
+              "examples": [
+                100
+              ],
+              "default": 100
+            },
+            "description": "Number of items to be sampled"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "Offset param",
+              "description": "Offset quantity to start sampling from",
+              "examples": [
+                10
+              ],
+              "default": 0
+            },
+            "description": "Offset quantity to start sampling from"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Example `2024-04-24 00:00:00`"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`",
+              "examples": [
+                "%Y-%m-%d %H:%M:%S",
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Example `2024-04-24 23:59:59`"
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "title": "Search text",
+              "description": "Search text for fields \"name\""
+            },
+            "description": "Search text for fields \"name\""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RosConfigPayloadResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ros/{id}": {
+      "get": {
+        "tags": [
+          "RoS Configs"
+        ],
+        "summary": "Get Router Os Configs By Id",
+        "description": "Get a Router OS configs by id",
+        "operationId": "Get_Router_OS_configs_by_id_ros__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Router OS configs record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RosConfigElementResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResp"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RoS Configs"
+        ],
+        "summary": "Delete One Routeros Config",
+        "description": "Delete once RouterOS config record",
+        "operationId": "Delete_one_RouterOS_config_ros__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Router OS configs record ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commands/lists/load": {
+      "post": {
+        "tags": [
+          "Commands"
+        ],
+        "summary": "Download Domains And Ips Lists",
+        "description": "Start background task for download domains and ips lists if hash files changed",
+        "operationId": "Download_domains_and_ips_lists_commands_lists_load_post",
+        "parameters": [
+          {
+            "name": "forced",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Force reload lists",
+              "description": "Force reload lists",
+              "default": false
+            },
+            "description": "Force reload lists"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commands/domains/resolve/new": {
+      "post": {
+        "tags": [
+          "Commands"
+        ],
+        "summary": "Resolve New Domains",
+        "description": "Start background task for resolve only new domains. It can be done more often",
+        "operationId": "Resolve_new_domains_commands_domains_resolve_new_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commands/domains/resolve/stale": {
+      "post": {
+        "tags": [
+          "Commands"
+        ],
+        "summary": "Resolve Stale Domains",
+        "description": "Start background task for resolve stale domains. This should be done rarely because there are many such domains",
+        "operationId": "Resolve_stale_domains_commands_domains_resolve_stale_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commands/ros/update": {
+      "post": {
+        "tags": [
+          "Commands"
+        ],
+        "summary": "Update Firewall And Routing At Routeros Devices",
+        "description": "Update firewall address-list and routing records at all RouterOS devices(configs)",
+        "operationId": "Update_firewall_and_routing_at_RouterOS_devices_commands_ros_update_post",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "IP address type v4 or v6",
+              "description": "IP address type filter parameter",
+              "examples": [
+                4,
+                6
+              ]
+            },
+            "description": "IP address type filter parameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats": {
+      "get": {
+        "tags": [
+          "Statistics"
+        ],
+        "summary": "Get All Statistics Total Data",
+        "description": "Displays all all statistics total data",
+        "operationId": "Get_all_statistics_total_data_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/growth": {
+      "get": {
+        "tags": [
+          "Statistics"
+        ],
+        "summary": "Get Growth Time Series",
+        "description": "Time series of record creation grouped by date/week/month.",
+        "operationId": "Get_Growth_Time_Series_stats_growth_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/GrowthEntity",
+              "description": "Data entity to aggregate",
+              "examples": [
+                "domains",
+                "lists",
+                "ips"
+              ]
+            },
+            "description": "Data entity to aggregate"
+          },
+          {
+            "name": "granularity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/GrowthGranularity",
+              "description": "Time grouping granularity",
+              "examples": [
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year"
+              ],
+              "default": "day"
+            },
+            "description": "Time grouping granularity"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start date",
+              "description": "Date from which you want to start sampling. Format '%Y-%m-%d %H:%M:%S'",
+              "examples": [
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to start sampling. Format '%Y-%m-%d %H:%M:%S'"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 19,
+                  "maxLength": 19
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End date",
+              "description": "Date from which you want to end sampling. Format '%Y-%m-%d %H:%M:%S'",
+              "examples": [
+                "2024-10-01 15:00:00"
+              ]
+            },
+            "description": "Date from which you want to end sampling. Format '%Y-%m-%d %H:%M:%S'"
+          },
+          {
+            "name": "ip_subtype",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IP version filter, only for entity=\"ips\". Allowed: 4 or 6",
+              "examples": [
+                4,
+                6
+              ],
+              "title": "Ip Subtype"
+            },
+            "description": "IP version filter, only for entity=\"ips\". Allowed: 4 or 6"
+          },
+          {
+            "name": "date_filter_field",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/GrowthDateField",
+              "description": "Field to filter by date. \"last_resolved_at\" only for entity=\"domains\"",
+              "examples": [
+                "created_at",
+                "updated_at",
+                "last_resolved_at"
+              ],
+              "default": "created_at"
+            },
+            "description": "Field to filter by date. \"last_resolved_at\" only for entity=\"domains\""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsGrowthResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ConfigDynamic": {
+        "properties": {
+          "ip_not_allowed_list": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ip Not Allowed List"
+          },
+          "app_title_metrics": {
+            "type": "string",
+            "title": "App Title Metrics"
+          },
+          "db_path": {
+            "type": "string",
+            "title": "Db Path"
+          },
+          "db_connection": {
+            "type": "string",
+            "title": "Db Connection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ip_not_allowed_list",
+          "app_title_metrics",
+          "db_path",
+          "db_connection"
+        ],
+        "title": "ConfigDynamic"
+      },
+      "ConfigResp": {
+        "properties": {
+          "static": {
+            "$ref": "#/components/schemas/ConfigStatic"
+          },
+          "dynamic": {
+            "$ref": "#/components/schemas/ConfigDynamic"
+          }
+        },
+        "type": "object",
+        "required": [
+          "static",
+          "dynamic"
+        ],
+        "title": "ConfigResp"
+      },
+      "ConfigStatic": {
+        "properties": {
+          "root_path": {
+            "type": "string",
+            "title": "Root Path"
+          },
+          "root_log_level": {
+            "type": "string",
+            "title": "Root Log Level"
+          },
+          "app_title": {
+            "type": "string",
+            "title": "App Title"
+          },
+          "app_summary": {
+            "type": "string",
+            "title": "App Summary"
+          },
+          "app_description": {
+            "type": "string",
+            "title": "App Description"
+          },
+          "app_debug": {
+            "type": "boolean",
+            "title": "App Debug"
+          },
+          "app_version": {
+            "type": "string",
+            "title": "App Version"
+          },
+          "app_host": {
+            "type": "string",
+            "title": "App Host"
+          },
+          "app_port": {
+            "type": "integer",
+            "title": "App Port"
+          },
+          "app_log_level": {
+            "type": "string",
+            "title": "App Log Level"
+          },
+          "queue_max_size": {
+            "type": "integer",
+            "title": "Queue Max Size"
+          },
+          "queue_get_timeout": {
+            "type": "number",
+            "title": "Queue Get Timeout"
+          },
+          "queue_sleep_timeout": {
+            "type": "number",
+            "title": "Queue Sleep Timeout"
+          },
+          "db_log_level": {
+            "type": "string",
+            "title": "Db Log Level"
+          },
+          "db_timeout": {
+            "type": "number",
+            "title": "Db Timeout"
+          },
+          "db_base_dir": {
+            "type": "string",
+            "title": "Db Base Dir"
+          },
+          "db_file_name": {
+            "type": "string",
+            "title": "Db File Name"
+          },
+          "db_table_prefix": {
+            "type": "string",
+            "title": "Db Table Prefix"
+          },
+          "db_save_batch_size": {
+            "type": "integer",
+            "title": "Db Save Batch Size"
+          },
+          "db_save_batch_timeout": {
+            "type": "number",
+            "title": "Db Save Batch Timeout"
+          },
+          "attempts_limit": {
+            "type": "integer",
+            "title": "Attempts Limit"
+          },
+          "req_connection_retries": {
+            "type": "integer",
+            "title": "Req Connection Retries"
+          },
+          "req_timeout_default": {
+            "type": "number",
+            "title": "Req Timeout Default"
+          },
+          "req_timeout_connect": {
+            "type": "number",
+            "title": "Req Timeout Connect"
+          },
+          "req_timeout_read": {
+            "type": "number",
+            "title": "Req Timeout Read"
+          },
+          "req_max_connections": {
+            "type": "integer",
+            "title": "Req Max Connections"
+          },
+          "req_max_keepalive_connections": {
+            "type": "integer",
+            "title": "Req Max Keepalive Connections"
+          },
+          "req_ssl_verify": {
+            "type": "boolean",
+            "title": "Req Ssl Verify"
+          },
+          "req_default_limit": {
+            "type": "integer",
+            "title": "Req Default Limit"
+          },
+          "domains_filtered_min_len": {
+            "type": "integer",
+            "title": "Domains Filtered Min Len"
+          },
+          "domains_update_interval": {
+            "type": "integer",
+            "title": "Domains Update Interval"
+          },
+          "domain_resolve_semaphore_limit": {
+            "type": "integer",
+            "title": "Domain Resolve Semaphore Limit"
+          },
+          "domains_black_list": {
+            "type": "string",
+            "title": "Domains Black List"
+          },
+          "lists_update_interval_sec": {
+            "type": "integer",
+            "title": "Lists Update Interval Sec"
+          },
+          "ip_not_allowed": {
+            "type": "string",
+            "title": "Ip Not Allowed"
+          },
+          "ros_rest_api_read_timeout": {
+            "type": "number",
+            "title": "Ros Rest Api Read Timeout"
+          }
+        },
+        "type": "object",
+        "required": [
+          "root_path",
+          "root_log_level",
+          "app_title",
+          "app_summary",
+          "app_description",
+          "app_debug",
+          "app_version",
+          "app_host",
+          "app_port",
+          "app_log_level",
+          "queue_max_size",
+          "queue_get_timeout",
+          "queue_sleep_timeout",
+          "db_log_level",
+          "db_timeout",
+          "db_base_dir",
+          "db_file_name",
+          "db_table_prefix",
+          "db_save_batch_size",
+          "db_save_batch_timeout",
+          "attempts_limit",
+          "req_connection_retries",
+          "req_timeout_default",
+          "req_timeout_connect",
+          "req_timeout_read",
+          "req_max_connections",
+          "req_max_keepalive_connections",
+          "req_ssl_verify",
+          "req_default_limit",
+          "domains_filtered_min_len",
+          "domains_update_interval",
+          "domain_resolve_semaphore_limit",
+          "domains_black_list",
+          "lists_update_interval_sec",
+          "ip_not_allowed",
+          "ros_rest_api_read_timeout"
+        ],
+        "title": "ConfigStatic"
+      },
+      "DnsElementResp": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "server": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Server"
+          },
+          "doh_server": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Doh Server"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_at_hum": {
+            "type": "string",
+            "title": "Created At Hum"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_at_hum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At Hum"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created_at",
+          "created_at_hum"
+        ],
+        "title": "DnsElementResp"
+      },
+      "DnsPayloadResp": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "duration": {
+            "type": "number",
+            "title": "Duration"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "default": 0
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "payload": {
+            "items": {
+              "$ref": "#/components/schemas/DnsElementResp"
+            },
+            "type": "array",
+            "title": "Payload",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit",
+          "offset",
+          "duration"
+        ],
+        "title": "DnsPayloadResp"
+      },
+      "DnsPostElementReq": {
+        "properties": {
+          "server": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "IPv4, IPv6 DNS server address"
+          },
+          "doh_server": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "DoH server HTTP address"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Some description for DNS server"
+          }
+        },
+        "type": "object",
+        "title": "DnsPostElementReq"
+      },
+      "DomainElementResp": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "domains_list_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domains List Id"
+          },
+          "resolved": {
+            "type": "boolean",
+            "title": "Resolved"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ros_comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ros Comment"
+          },
+          "ips_v4": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ips V4"
+          },
+          "ips_v6": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ips V6"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_at_hum": {
+            "type": "string",
+            "title": "Created At Hum"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_at_hum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At Hum"
+          },
+          "last_resolved_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Resolved At"
+          },
+          "last_resolved_at_hum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Resolved At Hum"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "resolved",
+          "name",
+          "created_at",
+          "created_at_hum"
+        ],
+        "title": "DomainElementResp"
+      },
+      "DomainsListElementResp": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hash"
+          },
+          "attempts": {
+            "type": "integer",
+            "title": "Attempts",
+            "default": 0
+          },
+          "elements_count": {
+            "type": "integer",
+            "title": "Elements Count",
+            "default": 0
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_at_hum": {
+            "type": "string",
+            "title": "Created At Hum"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_at_hum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At Hum"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "url",
+          "created_at",
+          "created_at_hum"
+        ],
+        "title": "DomainsListElementResp"
+      },
+      "DomainsListsPayloadResp": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "duration": {
+            "type": "number",
+            "title": "Duration"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "default": 0
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "payload": {
+            "items": {
+              "$ref": "#/components/schemas/DomainsListElementResp"
+            },
+            "type": "array",
+            "title": "Payload",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit",
+          "offset",
+          "duration"
+        ],
+        "title": "DomainsListsPayloadResp"
+      },
+      "DomainsListsPostElementReq": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "title": "Domain list name",
+            "examples": [
+              "voice-domains-list"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "minLength": 5,
+            "title": "Link to file with domain lists",
+            "examples": [
+              "https://somedomain.som/path/path/path/voice.txt"
+            ]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description for record"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "url"
+        ],
+        "title": "DomainsListsPostElementReq"
+      },
+      "DomainsPayloadResp": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "duration": {
+            "type": "number",
+            "title": "Duration"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "default": 0
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "total_resolved": {
+            "type": "integer",
+            "title": "Total Resolved",
+            "default": 0
+          },
+          "total_query": {
+            "type": "integer",
+            "title": "Total Query",
+            "default": 0
+          },
+          "payload": {
+            "items": {
+              "$ref": "#/components/schemas/DomainElementResp"
+            },
+            "type": "array",
+            "title": "Payload",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit",
+          "offset",
+          "duration"
+        ],
+        "title": "DomainsPayloadResp"
+      },
+      "DomainsPostElementReq": {
+        "properties": {
+          "domain": {
+            "type": "string",
+            "title": "Domain name",
+            "examples": [
+              "google.com"
+            ]
+          },
+          "list_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domains list id"
+          },
+          "ros_comment": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Router OS comment for addr-list and route",
+            "examples": [
+              "discord domain"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "domain"
+        ],
+        "title": "DomainsPostElementReq"
+      },
+      "ErrorResp": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "title": "Error"
+          },
+          "resolution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolution"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "title": "ErrorResp"
+      },
+      "GrowthDateField": {
+        "type": "string",
+        "enum": [
+          "created_at",
+          "updated_at",
+          "last_resolved_at"
+        ],
+        "title": "GrowthDateField"
+      },
+      "GrowthEntity": {
+        "type": "string",
+        "enum": [
+          "domains",
+          "lists",
+          "ips"
+        ],
+        "title": "GrowthEntity"
+      },
+      "GrowthGranularity": {
+        "type": "string",
+        "enum": [
+          "minute",
+          "hour",
+          "day",
+          "week",
+          "month",
+          "year"
+        ],
+        "title": "GrowthGranularity"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HealthResp": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Application status",
+            "default": "OK"
+          },
+          "ts": {
+            "type": "number",
+            "title": "Response now timestamp"
+          },
+          "uptime": {
+            "type": "number",
+            "title": "Application uptime"
+          },
+          "db_pool": {
+            "type": "string",
+            "title": "Database pool status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ts",
+          "uptime",
+          "db_pool"
+        ],
+        "title": "HealthResp"
+      },
+      "IpsElementResp": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "type": {
+            "type": "integer",
+            "title": "Type"
+          },
+          "addr": {
+            "type": "string",
+            "title": "Addr"
+          },
+          "ip_list_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip List Id"
+          },
+          "ip_list_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip List Name"
+          },
+          "domain_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domain Id"
+          },
+          "domain_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domain Name"
+          },
+          "ros_comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ros Comment"
+          },
+          "use_default_gw": {
+            "type": "boolean",
+            "title": "Use Default Gw",
+            "default": false
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_at_hum": {
+            "type": "string",
+            "title": "Created At Hum"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_at_hum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At Hum"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "addr",
+          "created_at",
+          "created_at_hum"
+        ],
+        "title": "IpsElementResp"
+      },
+      "IpsListElementResp": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hash"
+          },
+          "attempts": {
+            "type": "integer",
+            "title": "Attempts",
+            "default": 0
+          },
+          "elements_count": {
+            "type": "integer",
+            "title": "Elements Count",
+            "default": 0
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_at_hum": {
+            "type": "string",
+            "title": "Created At Hum"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_at_hum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At Hum"
+          },
+          "ip_v4_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip V4 Count"
+          },
+          "ip_v6_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip V6 Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "url",
+          "created_at",
+          "created_at_hum"
+        ],
+        "title": "IpsListElementResp"
+      },
+      "IpsListsPayloadResp": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "duration": {
+            "type": "number",
+            "title": "Duration"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "default": 0
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "payload": {
+            "items": {
+              "$ref": "#/components/schemas/IpsListElementResp"
+            },
+            "type": "array",
+            "title": "Payload",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit",
+          "offset",
+          "duration"
+        ],
+        "title": "IpsListsPayloadResp"
+      },
+      "IpsListsPostElementReq": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "title": "IP address list name",
+            "examples": [
+              "goog.json"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "minLength": 5,
+            "title": "Link to file with IP address lists",
+            "examples": [
+              "https://somedomain.som/path/path/path/goog.json"
+            ]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description for record"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "url"
+        ],
+        "title": "IpsListsPostElementReq"
+      },
+      "IpsPayloadResp": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "duration": {
+            "type": "number",
+            "title": "Duration"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "default": 0
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "payload": {
+            "items": {
+              "$ref": "#/components/schemas/IpsElementResp"
+            },
+            "type": "array",
+            "title": "Payload",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit",
+          "offset",
+          "duration"
+        ],
+        "title": "IpsPayloadResp"
+      },
+      "IpsPostElementReq": {
+        "properties": {
+          "addr": {
+            "type": "string",
+            "title": "IP address record",
+            "examples": [
+              "1.1.1.1",
+              "9.9.9.9",
+              "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+            ]
+          },
+          "list_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linked ips list ID"
+          },
+          "domain_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linked domain ID",
+            "description": "Linked domain ID. Default = `0`",
+            "default": 0
+          },
+          "ros_comment": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Router OS comment for addr and route",
+            "examples": [
+              "discord ip address"
+            ]
+          },
+          "use_default_gw": {
+            "type": "boolean",
+            "title": "Not use VPN gateway. Use default client router gateway",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "addr"
+        ],
+        "title": "IpsPostElementReq"
+      },
+      "NoDataResp": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "No Data"
+          }
+        },
+        "type": "object",
+        "title": "NoDataResp"
+      },
+      "NotFoundResp": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "title": "Error",
+            "default": "NOT_FOUND"
+          },
+          "resolution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolution"
+          }
+        },
+        "type": "object",
+        "title": "NotFoundResp"
+      },
+      "OkResp": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "title": "Result OK",
+            "default": "OK"
+          }
+        },
+        "type": "object",
+        "title": "OkResp"
+      },
+      "RosConfigElementResp": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "host": {
+            "type": "string",
+            "title": "Host"
+          },
+          "user": {
+            "type": "string",
+            "title": "User"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "bgp_list_name": {
+            "type": "string",
+            "title": "Bgp List Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_at_hum": {
+            "type": "string",
+            "title": "Created At Hum"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_at_hum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At Hum"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "host",
+          "user",
+          "password",
+          "bgp_list_name",
+          "created_at",
+          "created_at_hum"
+        ],
+        "title": "RosConfigElementResp"
+      },
+      "RosConfigPayloadResp": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "duration": {
+            "type": "number",
+            "title": "Duration"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "default": 0
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "payload": {
+            "items": {
+              "$ref": "#/components/schemas/RosConfigElementResp"
+            },
+            "type": "array",
+            "title": "Payload",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit",
+          "offset",
+          "duration"
+        ],
+        "title": "RosConfigPayloadResp"
+      },
+      "RosConfigsPostElementReq": {
+        "properties": {
+          "host": {
+            "type": "string",
+            "minLength": 3,
+            "title": "RouterOS IP address or domain"
+          },
+          "user": {
+            "type": "string",
+            "minLength": 3,
+            "title": "User in RouterOS"
+          },
+          "user_password": {
+            "type": "string",
+            "minLength": 3,
+            "title": "User password. If you don't use a password, why are you doing it?"
+          },
+          "bgp_list_name": {
+            "type": "string",
+            "minLength": 3,
+            "title": "BGP list name",
+            "description": "BGP list name. Used for the list in the Firewall address list and routing table naming"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description for record"
+          }
+        },
+        "type": "object",
+        "required": [
+          "host",
+          "user",
+          "user_password",
+          "bgp_list_name"
+        ],
+        "title": "RosConfigsPostElementReq"
+      },
+      "StatsDnsData": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total DNS server records",
+            "default": 0
+          },
+          "classic": {
+            "type": "integer",
+            "title": "Classic",
+            "description": "Classic IPv4/IPv6 DNS servers",
+            "default": 0
+          },
+          "doh": {
+            "type": "integer",
+            "title": "Doh",
+            "description": "DNS-over-HTTPS servers",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "StatsDnsData"
+      },
+      "StatsDomainsData": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total domain records",
+            "default": 0
+          },
+          "resolved": {
+            "type": "integer",
+            "title": "Resolved",
+            "description": "Resolved domains",
+            "default": 0
+          },
+          "unresolved": {
+            "type": "integer",
+            "title": "Unresolved",
+            "description": "Unresolved domains",
+            "default": 0
+          },
+          "lists_total": {
+            "type": "integer",
+            "title": "Lists Total",
+            "description": "Total domain lists",
+            "default": 0
+          },
+          "per_list": {
+            "items": {
+              "$ref": "#/components/schemas/StatsDomainsListItem"
+            },
+            "type": "array",
+            "title": "Per List",
+            "description": "Per-list breakdown for bar chart"
+          }
+        },
+        "type": "object",
+        "title": "StatsDomainsData"
+      },
+      "StatsDomainsListItem": {
+        "properties": {
+          "list_id": {
+            "type": "integer",
+            "title": "List Id",
+            "description": "Domain list ID"
+          },
+          "list_name": {
+            "type": "string",
+            "title": "List Name",
+            "description": "Domain list name"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total domains in this list",
+            "default": 0
+          },
+          "resolved": {
+            "type": "integer",
+            "title": "Resolved",
+            "description": "Resolved domains count",
+            "default": 0
+          },
+          "unresolved": {
+            "type": "integer",
+            "title": "Unresolved",
+            "description": "Unresolved domains count",
+            "default": 0
+          },
+          "attempts": {
+            "type": "integer",
+            "title": "Attempts",
+            "description": "Download attempts count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "list_id",
+          "list_name"
+        ],
+        "title": "StatsDomainsListItem"
+      },
+      "StatsGrowthPoint": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date",
+            "description": "Aggregated date label (format depends on granularity)",
+            "examples": [
+              "2025-01-15",
+              "2025-03",
+              "2025-01"
+            ]
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "description": "Number of records created in this period",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "date"
+        ],
+        "title": "StatsGrowthPoint"
+      },
+      "StatsGrowthResp": {
+        "properties": {
+          "entity": {
+            "$ref": "#/components/schemas/GrowthEntity",
+            "description": "Requested entity"
+          },
+          "granularity": {
+            "$ref": "#/components/schemas/GrowthGranularity",
+            "description": "Applied granularity"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date",
+            "description": "Applied start date filter"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date",
+            "description": "Applied end date filter"
+          },
+          "ip_subtype": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip Subtype",
+            "description": "Applied IP version filter (only for entity=ips)"
+          },
+          "total_in_period": {
+            "type": "integer",
+            "title": "Total In Period",
+            "description": "Total records in the requested period",
+            "default": 0
+          },
+          "payload": {
+            "items": {
+              "$ref": "#/components/schemas/StatsGrowthPoint"
+            },
+            "type": "array",
+            "title": "Payload",
+            "description": "Time series data points. All dates in range are included, missing dates have count=0"
+          },
+          "duration": {
+            "type": "number",
+            "title": "Duration",
+            "description": "Time taken to compute the response",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "entity",
+          "granularity"
+        ],
+        "title": "StatsGrowthResp"
+      },
+      "StatsIpsData": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total IP address records",
+            "default": 0
+          },
+          "v4_total": {
+            "type": "integer",
+            "title": "V4 Total",
+            "description": "Total IPv4 addresses",
+            "default": 0
+          },
+          "v6_total": {
+            "type": "integer",
+            "title": "V6 Total",
+            "description": "Total IPv6 addresses",
+            "default": 0
+          },
+          "linked_to_domain": {
+            "type": "integer",
+            "title": "Linked To Domain",
+            "description": "IPs resolved from domains (domain_id != 0)",
+            "default": 0
+          },
+          "standalone": {
+            "type": "integer",
+            "title": "Standalone",
+            "description": "IPs added manually (domain_id = 0)",
+            "default": 0
+          },
+          "lists_total": {
+            "type": "integer",
+            "title": "Lists Total",
+            "description": "Total IP lists",
+            "default": 0
+          },
+          "per_list": {
+            "items": {
+              "$ref": "#/components/schemas/StatsIpsListItem"
+            },
+            "type": "array",
+            "title": "Per List",
+            "description": "Per-list breakdown for bar chart"
+          }
+        },
+        "type": "object",
+        "title": "StatsIpsData"
+      },
+      "StatsIpsListItem": {
+        "properties": {
+          "list_id": {
+            "type": "integer",
+            "title": "List Id",
+            "description": "IP list ID"
+          },
+          "list_name": {
+            "type": "string",
+            "title": "List Name",
+            "description": "IP list name"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total IPs in this list",
+            "default": 0
+          },
+          "v4_count": {
+            "type": "integer",
+            "title": "V4 Count",
+            "description": "IPv4 count",
+            "default": 0
+          },
+          "v6_count": {
+            "type": "integer",
+            "title": "V6 Count",
+            "description": "IPv6 count",
+            "default": 0
+          },
+          "attempts": {
+            "type": "integer",
+            "title": "Attempts",
+            "description": "Download attempts count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "list_id",
+          "list_name"
+        ],
+        "title": "StatsIpsListItem"
+      },
+      "StatsResp": {
+        "properties": {
+          "generated_at": {
+            "type": "string",
+            "title": "Generated At",
+            "description": "Timestamp when aggregation was computed",
+            "examples": [
+              "2025-01-15 10:30:00"
+            ]
+          },
+          "dns": {
+            "$ref": "#/components/schemas/StatsDnsData"
+          },
+          "domains": {
+            "$ref": "#/components/schemas/StatsDomainsData"
+          },
+          "ips": {
+            "$ref": "#/components/schemas/StatsIpsData"
+          },
+          "ros": {
+            "$ref": "#/components/schemas/StatsRosData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "generated_at",
+          "dns",
+          "domains",
+          "ips",
+          "ros"
+        ],
+        "title": "StatsResp",
+        "description": "Example:\n```json\n{\n  \"generated_at\": \"2025-01-15 10:30:00\",\n  \"dns\": {\n    \"total\": 5,\n    \"classic\": 3,\n    \"doh\": 2\n  },\n  \"domains\": {\n    \"total\": 1500,\n    \"resolved\": 1200,\n    \"unresolved\": 300,\n    \"lists_total\": 4,\n    \"per_list\": [\n      { \"list_id\": 1, \"list_name\": \"voice-domains\", \"total\": 500, \"resolved\": 450, \"unresolved\": 50, \"attempts\": 3 },\n      { \"list_id\": 2, \"list_name\": \"social-domains\", \"total\": 1000, \"resolved\": 750, \"unresolved\": 250, \"attempts\": 1 }\n    ]\n  },\n  \"ips\": {\n    \"total\": 2000,\n    \"v4_total\": 1800,\n    \"v6_total\": 200,\n    \"linked_to_domain\": 1500,\n    \"standalone\": 500,\n    \"lists_total\": 3,\n    \"per_list\": [\n      { \"list_id\": 1, \"list_name\": \"ips-list\", \"total\": 800, \"v4_count\": 700, \"v6_count\": 100 }\n    ]\n  },\n  \"ros\": {\n    \"total\": 2\n  }\n}\n```"
+      },
+      "StatsRosData": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total RouterOS configurations",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "StatsRosData"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WelcomeResp": {
+        "properties": {
+          "version": {
+            "type": "string",
+            "title": "API Version"
+          },
+          "message": {
+            "type": "string",
+            "title": "Welcome message",
+            "default": "Welcome to API"
+          },
+          "docs": {
+            "type": "string",
+            "title": "link to docs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "version",
+          "docs"
+        ],
+        "title": "WelcomeResp"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Home",
+      "description": "Welcome method and healthcheck"
+    }
+  ]
+}

--- a/metrics/httpx_metrics.py
+++ b/metrics/httpx_metrics.py
@@ -41,7 +41,7 @@ class HttpxMetrics:
   exceptions: Counter = Counter(
     name='httpx_exceptions_total',
     documentation='Total count of exceptions raised by path and exception type',
-    labelnames=['method', 'host', 'path', 'status_code', 'error', 'detail', 'app_name']
+    labelnames=['method', 'host', 'path', 'status_code', 'error', 'app_name']
   )
   '''EXCEPTIONS'''
 
@@ -88,6 +88,5 @@ class HttpxMetrics:
         path=path,
         status_code=status_code,
         error=error,
-        detail=detail,
         app_name=self.app_name
       ).inc()

--- a/models/db/domains_dbo.py
+++ b/models/db/domains_dbo.py
@@ -159,26 +159,50 @@ class DomainsDbo(Dbo):
       raise err
 
   @classmethod
-  async def get_all_for_resolve(
+  async def get_stale_for_resolve(
     cls: type[Self],
-    db_session: AsyncSession
+    db_session: AsyncSession,
+    limit: int
   ) -> Sequence[Row[Tuple[int, str, int | None, int]]]:
     '''
     WHERE id > 0 AND (updated_at IS NULL OR (unixepoch(CURRENT_TIMESTAMP) - unixepoch(updated_at)) >= {DOMAINS_UPDATE_INTERVAL})
     '''
     try:
+      elapsed_expr = func.coalesce(func.unixepoch(func.current_timestamp()) - func.unixepoch(cls.last_resolved_at), 0)
+      #
       select_stmt: Select[Tuple[int, str, int | None, int]] = select(
         cls.id,
         cls.name,
         cls.domain_list_id,
-        text(f'COALESCE(unixepoch(CURRENT_TIMESTAMP) - unixepoch({cls.__tablename__}.{cls.last_resolved_at.property.key}), 0) AS elapsed')
+        elapsed_expr.label('elapsed')
       ).where(
         cls.id > 0,
-        or_(
-          cls.last_resolved_at == None,
-          text(f'elapsed >= {settings.domains_update_interval}')
-        )
-      )
+        cls.last_resolved_at.is_not(None),
+        elapsed_expr >= settings.domains_update_interval
+      ).order_by(cls.last_resolved_at, cls.id).limit(limit)
+      result: Result[Tuple[int, str, int | None, int]] = \
+        await db_session.execute(select_stmt)
+      #
+      return result.fetchall()
+    except Exception as err:
+      raise err
+
+  @classmethod
+  async def get_new_for_resolve(
+    cls: type[Self],
+    db_session: AsyncSession,
+    limit: int
+  ) -> Sequence[Row[Tuple[int, str, int | None, int]]]:
+    try:
+      select_stmt: Select[Tuple[int, str, int | None, int]] = select(
+        cls.id,
+        cls.name,
+        cls.domain_list_id,
+        literal(0).label('elapsed')
+      ).where(
+        cls.id > 0,
+        cls.last_resolved_at.is_(None)
+      ).order_by(cls.id).limit(limit)
       result: Result[Tuple[int, str, int | None, int]] = \
         await db_session.execute(select_stmt)
       #

--- a/models/db/domains_lists_dbo.py
+++ b/models/db/domains_lists_dbo.py
@@ -104,7 +104,7 @@ class DomainsListsDbo(Dbo):
       raise err
 
   @classmethod
-  async def get_for_update(cls: type[Self], db_session: AsyncSession) -> List[DomainsListDto]:
+  async def get_for_update(cls: type[Self], db_session: AsyncSession, forced: bool) -> List[DomainsListDto]:
     try:
       select_stmt: Select[Tuple[int, str, str, str | None, str | None, int, datetime, datetime | None]] = select(
         cls.id,
@@ -116,14 +116,20 @@ class DomainsListsDbo(Dbo):
         cls.created_at,
         cls.updated_at
       ).where(
-        and_(
-          cls.attempts < settings.attempts_limit,
+        cls.attempts < settings.attempts_limit
+      )
+      if forced is False:
+        elapsed_expr = func.coalesce(
+          func.unixepoch(func.current_timestamp()) - func.unixepoch(cls.updated_at),
+          settings.lists_update_interval_sec
+        )
+        select_stmt = select_stmt.where(
           or_(
-            cls.updated_at == None,
-            cls.updated_at >= (datetime.now() - timedelta(seconds=settings.lists_update_interval_sec))
+            cls.updated_at.is_(None),
+            elapsed_expr >= settings.lists_update_interval_sec
           )
         )
-      )
+      #
       exec_result: Result[Tuple[int, str, str, str | None, str | None, int, datetime, datetime | None]] = \
         await db_session.execute(select_stmt)
       result: List[DomainsListDto] = [

--- a/models/db/ips_lists_dbo.py
+++ b/models/db/ips_lists_dbo.py
@@ -96,8 +96,13 @@ class IpsListsDbo(Dbo):
       raise err
 
   @classmethod
-  async def get_for_update(cls: type[Self], db_session: AsyncSession) -> List[IpsListDto]:
+  async def get_for_update(cls: type[Self], db_session: AsyncSession, forced: bool) -> List[IpsListDto]:
     try:
+      elapsed_expr = func.coalesce(
+        func.unixepoch(func.current_timestamp()) - func.unixepoch(cls.updated_at),
+        settings.lists_update_interval_sec
+      )
+      #
       select_stmt: Select[Tuple[int, str, str, str | None, str | None, int, datetime, datetime | None]] = select(
         cls.id,
         cls.name,
@@ -108,14 +113,20 @@ class IpsListsDbo(Dbo):
         cls.created_at,
         cls.updated_at
       ).where(
-        and_(
-          cls.attempts < settings.attempts_limit,
+        cls.attempts < settings.attempts_limit
+      )
+      if forced is False:
+        elapsed_expr = func.coalesce(
+          func.unixepoch(func.current_timestamp()) - func.unixepoch(cls.updated_at),
+          settings.lists_update_interval_sec
+        )
+        select_stmt = select_stmt.where(
           or_(
-            cls.updated_at == None,
-            cls.updated_at >= (datetime.now() - timedelta(seconds=settings.lists_update_interval_sec))
+            cls.updated_at.is_(None),
+            elapsed_expr >= settings.lists_update_interval_sec
           )
         )
-      )
+      #
       exec_result: Result[Tuple[int, str, str, str | None, str | None, int, datetime, datetime | None]] = \
         await db_session.execute(select_stmt)
       result: List[IpsListDto] = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,22 +2,19 @@
 
 [[package]]
 name = "aiosqlite"
-version = "0.21.0"
+version = "0.22.1"
 description = "asyncio bridge to the standard sqlite3 module"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0"},
-    {file = "aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3"},
+    {file = "aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb"},
+    {file = "aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650"},
 ]
 
-[package.dependencies]
-typing_extensions = ">=4.0"
-
 [package.extras]
-dev = ["attribution (==1.7.1)", "black (==24.3.0)", "build (>=1.2)", "coverage[toml] (==7.6.10)", "flake8 (==7.0.0)", "flake8-bugbear (==24.12.12)", "flit (==3.10.1)", "mypy (==1.14.1)", "ufmt (==2.5.1)", "usort (==1.0.8.post1)"]
-docs = ["sphinx (==8.1.3)", "sphinx-mdinclude (==0.6.1)"]
+dev = ["attribution (==1.8.0)", "black (==25.11.0)", "build (>=1.2)", "coverage[toml] (==7.10.7)", "flake8 (==7.3.0)", "flake8-bugbear (==24.12.12)", "flit (==3.12.0)", "mypy (==1.19.0)", "ufmt (==2.8.0)", "usort (==1.0.8.post1)"]
+docs = ["sphinx (==8.1.3)", "sphinx-mdinclude (==0.6.2)"]
 
 [[package]]
 name = "annotated-doc"
@@ -144,26 +141,27 @@ wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
 
 [[package]]
 name = "fastapi"
-version = "0.122.1"
+version = "0.136.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.122.1-py3-none-any.whl", hash = "sha256:35cac3f1f14e38171f28d8e4ba2e7fa42a204b12249a9f13cfdf417bd8e86b52"},
-    {file = "fastapi-0.122.1.tar.gz", hash = "sha256:0fd815e8bd9a56afdd16b2f82b3e765116cd50714080f98caf732babf06d71a4"},
+    {file = "fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f"},
+    {file = "fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.40.0,<0.51.0"
+pydantic = ">=2.9.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
+typing-inspection = ">=0.4.2"
 
 [package.extras]
-all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
-standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
-standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "fastar (>=0.9.0)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "greenlet"
@@ -300,14 +298,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"},
-    {file = "idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242"},
+    {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
+    {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
 ]
 
 [package.extras]
@@ -339,14 +337,14 @@ type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-myp
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.38.0"
+version = "1.41.1"
 description = "OpenTelemetry Python API"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582"},
-    {file = "opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12"},
+    {file = "opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f"},
+    {file = "opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621"},
 ]
 
 [package.dependencies]
@@ -355,52 +353,55 @@ typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "opentelemetry-exporter-prometheus"
-version = "0.59b0"
+version = "0.62b1"
 description = "Prometheus Metric Exporter for OpenTelemetry"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "opentelemetry_exporter_prometheus-0.59b0-py3-none-any.whl", hash = "sha256:71ced23207abd15b30d1fe4e7e910dcaa7c2ff1f24a6ffccbd4fdded676f541b"},
-    {file = "opentelemetry_exporter_prometheus-0.59b0.tar.gz", hash = "sha256:d64f23c49abb5a54e271c2fbc8feacea0c394a30ec29876ab5ef7379f08cf3d7"},
+    {file = "opentelemetry_exporter_prometheus-0.62b1-py3-none-any.whl", hash = "sha256:7a0b8a6402e107e1f93e38f074a668797e1103936b189561959531a67ffeba55"},
+    {file = "opentelemetry_exporter_prometheus-0.62b1.tar.gz", hash = "sha256:7ecbac9aa76e7abb44082ab0ff2983e0a573e4091c4653f7db483b02bae03506"},
 ]
 
 [package.dependencies]
 opentelemetry-api = ">=1.12,<2.0"
-opentelemetry-sdk = ">=1.38.0,<1.39.0"
+opentelemetry-sdk = ">=1.41.1,<1.42.0"
 prometheus-client = ">=0.5.0,<1.0.0"
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.38.0"
+version = "1.41.1"
 description = "OpenTelemetry Python SDK"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "opentelemetry_sdk-1.38.0-py3-none-any.whl", hash = "sha256:1c66af6564ecc1553d72d811a01df063ff097cdc82ce188da9951f93b8d10f6b"},
-    {file = "opentelemetry_sdk-1.38.0.tar.gz", hash = "sha256:93df5d4d871ed09cb4272305be4d996236eedb232253e3ab864c8620f051cebe"},
+    {file = "opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d"},
+    {file = "opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6"},
 ]
 
 [package.dependencies]
-opentelemetry-api = "1.38.0"
-opentelemetry-semantic-conventions = "0.59b0"
+opentelemetry-api = "1.41.1"
+opentelemetry-semantic-conventions = "0.62b1"
 typing-extensions = ">=4.5.0"
+
+[package.extras]
+file-configuration = ["jsonschema (>=4.0)", "pyyaml (>=6.0)"]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.59b0"
+version = "0.62b1"
 description = "OpenTelemetry Semantic Conventions"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "opentelemetry_semantic_conventions-0.59b0-py3-none-any.whl", hash = "sha256:35d3b8833ef97d614136e253c1da9342b4c3c083bbaf29ce31d572a1c3825eed"},
-    {file = "opentelemetry_semantic_conventions-0.59b0.tar.gz", hash = "sha256:7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0"},
+    {file = "opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c"},
+    {file = "opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802"},
 ]
 
 [package.dependencies]
-opentelemetry-api = "1.38.0"
+opentelemetry-api = "1.41.1"
 typing-extensions = ">=4.5.0"
 
 [[package]]
@@ -422,19 +423,19 @@ twisted = ["twisted"]
 
 [[package]]
 name = "pydantic"
-version = "2.13.3"
+version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927"},
-    {file = "pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d"},
+    {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
+    {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.46.3"
+pydantic-core = "2.46.4"
 typing-extensions = ">=4.14.1"
 typing-inspection = ">=0.4.2"
 
@@ -444,132 +445,132 @@ timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.3"
+version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic_core-2.46.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:1da3786b8018e60349680720158cc19161cc3b4bdd815beb0a321cd5ce1ad5b1"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc0988cb29d21bf4a9d5cf2ef970b5c0e38d8d8e107a493278c05dc6c1dda69f"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f9067c3bfadd04c55484b89c0d267981b2f3512850f6f66e1e74204a4e4ce3"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a642ac886ecf6402d9882d10c405dcf4b902abeb2972cd5fb4a48c83cd59279a"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79f561438481f28681584b89e2effb22855e2179880314bcddbf5968e935e807"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57a973eae4665352a47cf1a99b4ee864620f2fe663a217d7a8da68a1f3a5bfda"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83d002b97072a53ea150d63e0a3adfae5670cef5aa8a6e490240e482d3b22e57"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b40ddd51e7c44b28cfaef746c9d3c506d658885e0a46f9eeef2ee815cbf8e045"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac5ec7fb9b87f04ee839af2d53bcadea57ded7d229719f56c0ed895bff987943"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a3b11c812f61b3129c4905781a2601dfdfdea5fe1e6c1cfb696b55d14e9c054f"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1108da631e602e5b3c38d6d04fe5bb3bfa54349e6918e3ca6cf570b2e2b2f9d4"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:de885175515bcfa98ae618c1df7a072f13d179f81376c8007112af20567fd08a"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-win32.whl", hash = "sha256:d11058e3201527d41bc6b545c79187c9e4bf85e15a236a6007f0e991518882b7"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-win_amd64.whl", hash = "sha256:3612edf65c8ea67ac13616c4d23af12faef1ae435a8a93e5934c2a0cbbdd1fd6"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ab124d49d0459b2373ecf54118a45c28a1e6d4192a533fbc915e70f556feb8e5"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cca67d52a5c7a16aed2b3999e719c4bcf644074eac304a5d3d62dd70ae7d4b2c"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c024e08c0ba23e6fd68c771a521e9d6a792f2ebb0fa734296b36394dc30390e"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6645ce7eec4928e29a1e3b3d5c946621d105d3e79f0c9cddf07c2a9770949287"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a712c7118e6c5ea96562f7b488435172abb94a3c53c22c9efc1412264a45cbbe"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69a868ef3ff206343579021c40faf3b1edc64b1cc508ff243a28b0a514ccb050"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc7e8c32db809aa0f6ea1d6869ebc8518a65d5150fdfad8bcae6a49ae32a22e2"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3481bd1341dc85779ee506bc8e1196a277ace359d89d28588a9468c3ecbe63fa"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8690eba565c6d68ffd3a8655525cbdd5246510b44a637ee2c6c03a7ebfe64d3c"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4de88889d7e88d50d40ee5b39d5dac0bcaef9ba91f7e536ac064e6b2834ecccf"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:e480080975c1ef7f780b8f99ed72337e7cc5efea2e518a20a692e8e7b278eb8b"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:de3a5c376f8cd94da9a1b8fd3dd1c16c7a7b216ed31dc8ce9fd7a22bf13b836e"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-win32.whl", hash = "sha256:fc331a5314ffddd5385b9ee9d0d2fee0b13c27e0e02dad71b1ae5d6561f51eeb"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-win_amd64.whl", hash = "sha256:b5b9c6cf08a8a5e502698f5e153056d12c34b8fb30317e0c5fd06f45162a6346"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-win_arm64.whl", hash = "sha256:5dfd51cf457482f04ec49491811a2b8fd5b843b64b11eecd2d7a1ee596ea78a6"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:fa3eb7c2995aa443687a825bc30395c8521b7c6ec201966e55debfd1128bcceb"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3d08782c4045f90724b44c95d35ebec0d67edb8a957a2ac81d5a8e4b8a200495"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:831eb19aa789a97356979e94c981e5667759301fb708d1c0d5adf1bc0098b873"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4335e87c7afa436a0dfa899e138d57a72f8aad542e2cf19c36fb428461caabd0"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99421e7684a60f7f3550a1d159ade5fdff1954baedb6bdd407cba6a307c9f27d"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd81f6907932ebac3abbe41378dac64b2380db1287e2aa64d8d88f78d170f51a"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f247596366f4221af52beddd65af1218797771d6989bc891a0b86ccaa019168"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:6dff8cc884679df229ebc6d8eb2321ea6f8e091bc7d4886d4dc2e0e71452843c"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68ef2f623dda6d5a9067ac014e406c020c780b2a358930a7e5c1b73702900720"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d56bdb4af1767cc15b0386b3c581fdfe659bb9ee4a4f776e92c1cd9d074000d6"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:91249bcb7c165c2fb2a2f852dbc5c91636e2e218e75d96dfdd517e4078e173dd"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b068543bdb707f5d935dab765d99227aa2545ef2820935f2e5dd801795c7dbd"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-win32.whl", hash = "sha256:dcda6583921c05a40533f982321532f2d8db29326c7b95c4026941fa5074bd79"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-win_amd64.whl", hash = "sha256:a35cc284c8dd7edae8a31533713b4d2467dfe7c4f1b5587dd4031f28f90d1d13"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:9715525891ed524a0a1eb6d053c74d4d4ad5017677fb00af0b7c2644a31bae46"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:9d2f400712a99a013aff420ef1eb9be077f8189a36c1e3ef87660b4e1088a874"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2aab0e2e9dc2daf36bd2686c982535d5e7b1d930a1344a7bb6e82baab42a76"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e9d76736da5f362fabfeea6a69b13b7f2be405c6d6966f06b2f6bfff7e64531"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:13afdd885f3d71280cf286b13b310ee0f7ccfefd1dbbb661514a474b726e2f25"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f91c0aff3e3ee0928edd1232c57f643a7a003e6edf1860bc3afcdc749cb513f3"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6529d1d128321a58d30afcc97b49e98836542f68dd41b33c2e972bb9e5290536"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:975c267cff4f7e7272eacbe50f6cc03ca9a3da4c4fbd66fffd89c94c1e311aa1"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2b8e4f2bbdf71415c544b4b1138b8060db7b6611bc927e8064c769f64bed651c"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e61ea8e9fff9606d09178f577ff8ccdd7206ff73d6552bcec18e1033c4254b85"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b504bda01bafc69b6d3c7a0c7f039dcf60f47fab70e06fe23f57b5c75bdc82b8"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b00b76f7142fc60c762ce579bd29c8fa44aaa56592dd3c54fab3928d0d4ca6ff"},
-    {file = "pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9f444c499b3eefd3a92e348059471ea0c3a6e303d9c1cec09fa748fd9f895201"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3447661d99f75a3683a4cf5c87da72f2161964611864dbbeac7fbb118bb4bfc0"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b9bab013d1c7a79d3501ff86d0bc9c31bf587db4551677b96bec07df78c6b15"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d995260fdf4e1db774581b4900e0f832abe3c7c84996726bbc161b19c8f29e76"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13a646d65d09fbf1bc6b3a9635d30095c8e7e5cc419ff35ecc563c5fd04cd49"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432c179df7874eeb73307aad2df0755e1ae0efa61ff0ea89b93e194411ae3928"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:e68b7a074f65a2fd746c52a7ce6142ab7006074ac269ace0c25cd8ba171f8066"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4a05d69cba51d852c5c3e92758653245a50c0b646ced0cf05bd793ed592839d6"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:228ee9bae8bef5b1e97ec58302f80357c37199e0d0a99174e138d28e6957b9d9"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:10e17cbb10a330363733efc4d7c4d0dd827ac0909b8f6a6542298fed1ea62f29"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:91a06d2e259ecfbd8c901d70c3c507900458498142b3026a296b7de4d1322cc9"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-win32.whl", hash = "sha256:d80ee3d731373b24cebbc10d689ca4ee1875caf0d5703a245db18efd4dd37fc1"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-win_amd64.whl", hash = "sha256:3be77f45df024d789a672ae34f8b06fb346c4f9f46ea714956660ea4862e89ac"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983"},
+    {file = "pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1"},
 ]
 
 [package.dependencies]
@@ -577,14 +578,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.14.1"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e"},
-    {file = "pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d"},
+    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
+    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
 ]
 
 [package.dependencies]
@@ -718,14 +719,14 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.0.0"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca"},
-    {file = "starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca"},
+    {file = "starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"},
+    {file = "starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149"},
 ]
 
 [package.dependencies]
@@ -775,14 +776,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "uvicorn"
-version = "0.38.0"
+version = "0.46.0"
 description = "The lightning-fast ASGI server."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02"},
-    {file = "uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d"},
+    {file = "uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048"},
+    {file = "uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d"},
 ]
 
 [package.dependencies]
@@ -790,7 +791,7 @@ click = ">=7.0"
 h11 = ">=0.8"
 
 [package.extras]
-standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.20)", "websockets (>=10.4)"]
 
 [[package]]
 name = "zipp"
@@ -815,4 +816,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "09399b7346df7c1e03c9e6c16a710ca853fb0d9b28c76e70764ab1bc36eaa088"
+content-hash = "50fe529f9a2546a5bd84effe050c455e914be6766d2a2dbfbb5c3cc09124efd2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ homepage = "https://gregory-gost.ru"
 repository = "https://github.com/GregoryGost/gost-rdpr"
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi (>=0.122.0,<0.123.0)",
+    "fastapi (>=0.136.1,<0.137.0)",
     "sqlalchemy (>=2.0.44,<3.0.0)",
-    "aiosqlite (>=0.21.0,<0.22.0)",
+    "aiosqlite (>=0.22.1,<0.23.0)",
     "dnspython (>=2.8.0,<3.0.0)",
-    "uvicorn (>=0.38.0,<0.39.0)",
+    "uvicorn (>=0.46.0,<0.47.0)",
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic-settings (>=2.12.0,<3.0.0)",
-    "opentelemetry-exporter-prometheus (>=0.59b0,<0.60)",
+    "opentelemetry-exporter-prometheus (>=0.62b1,<0.63)",
     "cashews (>=7.4.3,<8.0.0)",
     "toml (>=0.10.2,<0.11.0)",
 ]

--- a/routers/commands_router.py
+++ b/routers/commands_router.py
@@ -48,6 +48,7 @@ class CommandsRouter(BaseRouter):
       try:
         job_status: bool | None = await jobs_cache.get(Jobs.LISTS_LOAD)
         if job_status != True:
+          await jobs_cache.set(Jobs.LISTS_LOAD, True)
           background_tasks.add_task(db.lists_load, query.forced)
         else:
           return JSONResponse(
@@ -73,7 +74,7 @@ class CommandsRouter(BaseRouter):
       try:
         job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE)
         if job_status != True:
-          # default - Jobs.DOMAINS_RESOLVE_NEW
+          await jobs_cache.set(Jobs.DOMAINS_RESOLVE, True)
           background_tasks.add_task(
             self.domains_resolver.domains_resolve,
             Jobs.DOMAINS_RESOLVE_NEW
@@ -101,6 +102,7 @@ class CommandsRouter(BaseRouter):
       try:
         job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE)
         if job_status != True:
+          await jobs_cache.set(Jobs.DOMAINS_RESOLVE, True)
           background_tasks.add_task(
             self.domains_resolver.domains_resolve,
             Jobs.DOMAINS_RESOLVE_STALE
@@ -138,6 +140,7 @@ class CommandsRouter(BaseRouter):
           )
         job_status: bool | None = await jobs_cache.get(Jobs.ROS_UPDATE)
         if job_status != True:
+          await jobs_cache.set(Jobs.ROS_UPDATE, True)
           background_tasks.add_task(self.__ros_client.update, query.type)
         else:
           return JSONResponse(

--- a/routers/commands_router.py
+++ b/routers/commands_router.py
@@ -47,7 +47,7 @@ class CommandsRouter(BaseRouter):
       logger.debug(f'Call API route: POST /commands/lists/load')
       try:
         job_status: bool | None = await jobs_cache.get(Jobs.LISTS_LOAD)
-        if (job_status != None and job_status == False) or query.forced == True:
+        if job_status != True or query.forced == True:
           background_tasks.add_task(db.lists_load, query.forced)
         else:
           return JSONResponse(
@@ -60,23 +60,54 @@ class CommandsRouter(BaseRouter):
 
     # /domains/resolve
     @router.post(
-      path='/domains/resolve',
-      name='Resolve domains',
-      description='Start background task for resolve all domains',
+      path='/domains/resolve/new',
+      name='Resolve new domains',
+      description='Start background task for resolve only new domains. It can be done more often',
       response_model=OkResp,
       responses={
         status.HTTP_500_INTERNAL_SERVER_ERROR: {'model': ErrorResp},
       }
     )
-    async def domains_resolve_command(background_tasks: BackgroundTasks) -> JSONResponse:
-      logger.debug(f'Call API route: POST /commands/domains/resolve')
+    async def domains_resolve_new_command(background_tasks: BackgroundTasks) -> JSONResponse:
+      logger.debug(f'Call API route: POST /commands/domains/resolve/new')
       try:
-        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE)
-        if job_status != None and job_status == False:
-          background_tasks.add_task(self.domains_resolver.domains_resolve)
+        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE_NEW)
+        if job_status != True:
+          # default - Jobs.DOMAINS_RESOLVE_NEW
+          background_tasks.add_task(
+            self.domains_resolver.domains_resolve,
+            Jobs.DOMAINS_RESOLVE_NEW
+          )
         else:
           return JSONResponse(
-            OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE}] is now active').to_dict(),
+            OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE_NEW}] is now active').to_dict(),
+            status.HTTP_200_OK
+          )
+        return JSONResponse(OkResp().to_dict(), status.HTTP_200_OK)
+      except Exception as err:
+        return self.errorResp(err)
+      
+    @router.post(
+      path='/domains/resolve/stale',
+      name='Resolve stale domains',
+      description='Start background task for resolve stale domains. This should be done rarely because there are many such domains',
+      response_model=OkResp,
+      responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {'model': ErrorResp},
+      }
+    )
+    async def domains_resolve_stale_command(background_tasks: BackgroundTasks) -> JSONResponse:
+      logger.debug(f'Call API route: POST /commands/domains/resolve/stale')
+      try:
+        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE_STALE)
+        if job_status != True:
+          background_tasks.add_task(
+            self.domains_resolver.domains_resolve,
+            Jobs.DOMAINS_RESOLVE_STALE
+          )
+        else:
+          return JSONResponse(
+            OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE_STALE}] is now active').to_dict(),
             status.HTTP_200_OK
           )
         return JSONResponse(OkResp().to_dict(), status.HTTP_200_OK)

--- a/routers/commands_router.py
+++ b/routers/commands_router.py
@@ -47,7 +47,7 @@ class CommandsRouter(BaseRouter):
       logger.debug(f'Call API route: POST /commands/lists/load')
       try:
         job_status: bool | None = await jobs_cache.get(Jobs.LISTS_LOAD)
-        if job_status != True or query.forced == True:
+        if job_status != True:
           background_tasks.add_task(db.lists_load, query.forced)
         else:
           return JSONResponse(
@@ -71,7 +71,7 @@ class CommandsRouter(BaseRouter):
     async def domains_resolve_new_command(background_tasks: BackgroundTasks) -> JSONResponse:
       logger.debug(f'Call API route: POST /commands/domains/resolve/new')
       try:
-        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE_NEW)
+        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE)
         if job_status != True:
           # default - Jobs.DOMAINS_RESOLVE_NEW
           background_tasks.add_task(
@@ -80,7 +80,7 @@ class CommandsRouter(BaseRouter):
           )
         else:
           return JSONResponse(
-            OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE_NEW}] is now active').to_dict(),
+            OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE}] is now active').to_dict(),
             status.HTTP_200_OK
           )
         return JSONResponse(OkResp().to_dict(), status.HTTP_200_OK)
@@ -99,7 +99,7 @@ class CommandsRouter(BaseRouter):
     async def domains_resolve_stale_command(background_tasks: BackgroundTasks) -> JSONResponse:
       logger.debug(f'Call API route: POST /commands/domains/resolve/stale')
       try:
-        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE_STALE)
+        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE)
         if job_status != True:
           background_tasks.add_task(
             self.domains_resolver.domains_resolve,
@@ -107,7 +107,7 @@ class CommandsRouter(BaseRouter):
           )
         else:
           return JSONResponse(
-            OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE_STALE}] is now active').to_dict(),
+            OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE}] is now active').to_dict(),
             status.HTTP_200_OK
           )
         return JSONResponse(OkResp().to_dict(), status.HTTP_200_OK)

--- a/routers/home_router.py
+++ b/routers/home_router.py
@@ -108,7 +108,7 @@ class HomeRouter(BaseRouter):
           domains_filtered_min_len=settings.domains_filtered_min_len,
           domains_update_interval=settings.domains_update_interval,
           # domains_one_job_resolve_limit=settings.domains_one_job_resolve_limit,
-          domain_resolve_semaphore_limit=settings.domain_resolve_semaphore_limit,
+          domain_resolve_semaphore_limit=settings.domains_resolve_semaphore_limit,
           domains_black_list=settings.domains_black_list,
           lists_update_interval_sec=settings.lists_update_interval_sec,
           ip_not_allowed=settings.ip_not_allowed,

--- a/server/server.py
+++ b/server/server.py
@@ -68,7 +68,9 @@ class AppServer:
     # first RUN BEFORE start FastAPI
     # Cache init
     await jobs_cache.set(key=Jobs.LISTS_LOAD, value=False)
+    await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE, value=False)
     await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE_NEW, value=False)
+    await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE_STALE, value=False)
     await jobs_cache.set(key=Jobs.ROS_UPDATE, value=False)
     # Init DB
     await db.setup()

--- a/server/server.py
+++ b/server/server.py
@@ -15,6 +15,7 @@ from logger.logger import logger
 from database.db import db
 from cache.cache import jobs_cache
 from metrics.metrics import PrometheusMiddleware
+from client.http_base_client import HttpClient
 
 from .tags_metadata import TagsMetadata
 
@@ -79,6 +80,7 @@ class AppServer:
     #
     yield
     # next RUN AFTER stop FastAPI
+    await HttpClient.close()
 
   async def run(self: Self):
     logger.debug('AppServer run ...')

--- a/server/server.py
+++ b/server/server.py
@@ -68,7 +68,7 @@ class AppServer:
     # first RUN BEFORE start FastAPI
     # Cache init
     await jobs_cache.set(key=Jobs.LISTS_LOAD, value=False)
-    await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE, value=False)
+    await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE_NEW, value=False)
     await jobs_cache.set(key=Jobs.ROS_UPDATE, value=False)
     # Init DB
     await db.setup()


### PR DESCRIPTION
## Что изменено

- Разделена обработка доменов на отдельные режимы:
  - `/commands/domains/resolve/new` для новых доменов;
  - `/commands/domains/resolve/stale` для устаревших доменов.
- Добавлены отдельные лимиты batch-обработки для новых и устаревших доменов.
- Исправлена выборка доменов для повторного resolve без использования alias `elapsed` в `WHERE`.
- Исправлена логика выбора списков для обновления: теперь выбираются списки, которые не обновлялись дольше заданного интервала, а не недавно обновленные.
- Добавлены общие lock’и для фоновых задач, чтобы исключить параллельный запуск конфликтующих jobs.
- Исправлена обработка `Queue.task_done()` в domain resolve и RouterOS update workers.
- Снижено потребление памяти SQLite за счет настраиваемых PRAGMA:
  - `DB_TUNE_TEMP_STORE`
  - `DB_TUNE_MMAP_SIZE`
  - `DB_TUNE_CACHE_SIZE`
- Переведена загрузка списков на streaming-обработку.
- Убран label `detail` из HTTPX Prometheus-метрик.
- Доработан lifecycle HTTP-клиентов: добавлены named clients и корректное закрытие на shutdown.
- Обновлены README и OpenAPI-документация.

## Важные изменения в эксплуатации

Scheduler на RouterOS должен быть обновлен:

`/commands/domains/resolve` заменен на два отдельных.

- `/commands/domains/resolve/new` резолвинг только новых доменов, можно вызывать чаще;
- `/commands/domains/resolve/stale` резолвинг уже определенных ранее доменов, должен вызываться реже т.к. больше объемы;