### PR TITLE
Проверка доменов по имени и ID

### DIFF
--- a/docs/OPENAPI.json
+++ b/docs/OPENAPI.json
@@ -4,7 +4,7 @@
     "title": "GOST-RDPR (Resolve Domains Per Records)",
     "summary": "A utility for working with Mikrotik RouterOS and BGP protocol for announcing IP addresses",
     "description": "The utility provides parsing of domain names into IP addresses, processing of domain lists and their \n    subsequent parsing, processing of individual IP addresses and summarized IP groups. Updates firewall address list \n    and routing table",
-    "version": "2.0.9"
+    "version": "2.1.0"
   },
   "paths": {
     "/metrics": {
@@ -1626,6 +1626,121 @@
                 }
               }
             }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/domains/resolve/check": {
+      "post": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Resolve Domain Once",
+        "description": "Resolve a domain using configured DNS servers without saving the result to the database",
+        "operationId": "Resolve_domain_once_domains_resolve_check_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DomainResolveReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainResolveResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/domains/{id}/resolve": {
+      "post": {
+        "tags": [
+          "Domains"
+        ],
+        "summary": "Resolve Domain Now",
+        "operationId": "resolve_domain_now_domains__id__resolve_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResp"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResp"
+                }
+              }
+            },
+            "description": "Not Found"
           },
           "500": {
             "content": {
@@ -4043,6 +4158,45 @@
         "type": "object",
         "title": "DnsPostElementReq"
       },
+      "DnsServerResolveResultResp": {
+        "properties": {
+          "server": {
+            "type": "string",
+            "title": "Server"
+          },
+          "server_type": {
+            "type": "string",
+            "title": "Server Type"
+          },
+          "ips_v4": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ips V4"
+          },
+          "ips_v6": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ips V6"
+          },
+          "cnames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Cnames"
+          }
+        },
+        "type": "object",
+        "required": [
+          "server",
+          "server_type"
+        ],
+        "title": "DnsServerResolveResultResp"
+      },
       "DomainElementResp": {
         "properties": {
           "id": {
@@ -4182,6 +4336,64 @@
           "created_at_hum"
         ],
         "title": "DomainElementResp"
+      },
+      "DomainResolveReq": {
+        "properties": {
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 253,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domain name",
+            "description": "Domain name for one-time resolving without saving to database",
+            "examples": [
+              "example.com"
+            ]
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Existing domain ID",
+            "examples": [
+              123
+            ]
+          }
+        },
+        "type": "object",
+        "title": "DomainResolveReq"
+      },
+      "DomainResolveResp": {
+        "properties": {
+          "domain": {
+            "type": "string",
+            "title": "Domain"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/DnsServerResolveResultResp"
+            },
+            "type": "array",
+            "title": "Results"
+          }
+        },
+        "type": "object",
+        "required": [
+          "domain"
+        ],
+        "title": "DomainResolveResp"
       },
       "DomainsListElementResp": {
         "properties": {

--- a/models/http/domains_req.py
+++ b/models/http/domains_req.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, Field, field_validator
-from typing import Annotated, Optional
+from pydantic import BaseModel, Field, field_validator, model_validator
+from typing import Annotated, Optional, Self
 
 from .base import LimitOffsetQuery
 
@@ -33,19 +33,31 @@ class DomainsPostElementReq(BaseModel):
   )] = None
 
 class DomainResolveReq(BaseModel):
-  domain: Annotated[str, Field(
+  domain: Annotated[Optional[str], Field(
     title='Domain name',
     description='Domain name for one-time resolving without saving to database',
     min_length=1,
     max_length=253,
     examples=['example.com']
-  )]
+  )] = None
+  id: Annotated[Optional[int], Field(
+    title='Existing domain ID',
+    gt=0,
+    examples=[123]
+  )] = None
 
   @field_validator('domain')
   @classmethod
-  def normalize_domain(cls, value: str) -> str:
+  def normalize_domain(cls, value: str | None) -> str | None:
+    if value is None:
+      return None
     domain: str = value.strip().rstrip('.')
     if not domain:
       raise ValueError('Domain name must not be empty')
     return domain
   
+  @model_validator(mode='after')
+  def validate_resolve_source(self: Self) -> Self:
+    if (self.domain is None) == (self.id is None):
+      raise ValueError('Specify exactly one of "domain" or "id"')
+    return self

--- a/routers/domains_router.py
+++ b/routers/domains_router.py
@@ -190,7 +190,24 @@ class DomainsRouter(BaseRouter):
     async def resolve_domain_once(data: Annotated[DomainResolveReq, Body()]) -> JSONResponse:
       logger.debug('Call API route: POST /domains/resolve/check')
       try:
-        result: CheckDomainResultDto = await self.__domains_resolver.resolve_once(domain_name=data.domain)
+        domain_name: str | None = data.domain
+        #
+        if data.id is not None:
+          domain_record: DomainElementResp | None = await db.get_domain_on_id(id=data.id)
+          if domain_record is None:
+            not_found_resp: NotFoundResp = NotFoundResp(
+              resolution=f"Domain with ID '{data.id}' not found in local db"
+            )
+            return JSONResponse(
+              content=not_found_resp.to_dict(),
+              status_code=status.HTTP_404_NOT_FOUND
+            )
+          logger.debug(f'Domain found on ID={data.id} for single resolve. Domain name={domain_record.name}')
+          domain_name = domain_record.name
+        if domain_name is None:
+          raise ValueError('Domain name is not defined')
+        #
+        result: CheckDomainResultDto = await self.__domains_resolver.resolve_once(domain_name=domain_name)
         return_data: DomainResolveResp = DomainResolveResp(
           domain=result.domain,
           results=[


### PR DESCRIPTION
- Запрос /domains/resolve/check расширен взаимоисключающими полями domain и id
- Для существующего ID добавлены загрузка имени домена и ответ 404 при отсутствии записи
- OpenAPI-схема синхронизирована с маршрутами DNS-резолвинга