### PR TITLE
Выбор DNS-серверов для проверки доменов

### DIFF
--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -31,6 +31,7 @@ from utils.utils import get_ip_version
 
 from models.http.domains_req import DomainsPostElementReq
 from models.http.domains_resp import DomainElementResp
+from models.http.dns_servers_resp import DnsElementResp
 
 from models.dto.domains_dto import DomainResult, CheckDomainResultDto, DnsServerResolveResultDto
 from models.dto.dns_server_dto import DnsServerDto
@@ -403,15 +404,27 @@ class DomainsResolver:
       await jobs_cache.set(job_mode, False)
       await jobs_cache.set(Jobs.DOMAINS_RESOLVE, False)
 
-  async def resolve_once(self: Self, domain_name: str) -> CheckDomainResultDto:
+  async def resolve_once(
+    self: Self,
+    domain_name: str,
+    selected_dns_servers: List[DnsElementResp] | None = None
+  ) -> CheckDomainResultDto:
     name: str = domain_name.strip().rstrip('.')
     if not name:
       raise ValueError('Domain name must not be empty')
-    domain: DomainResult = DomainResult(
-      id=0,
-      name=name
-    )
-    default_dns_servers, doh_dns_servers = await db.get_dns_servers_for_resolve()
+    #
+    default_dns_servers: List[DnsServerDto] = []
+    doh_dns_servers: List[DnsServerDto] = []
+    if selected_dns_servers is None:
+      default_dns_servers, doh_dns_servers = await db.get_dns_servers_for_resolve()
+    else:
+      for selected_dns_server in selected_dns_servers:
+        if selected_dns_server.server is not None:
+          default_dns_servers.append(DnsServerDto(server=selected_dns_server.server))
+        elif selected_dns_server.doh_server is not None:
+          doh_dns_servers.append(DnsServerDto(server=selected_dns_server.doh_server))
+        else:
+          raise RuntimeError(f'DNS server ID={selected_dns_server.id} does not contain a server address')
     #
     tasks: list[CoroutineType] = []
     #

--- a/docs/OPENAPI.json
+++ b/docs/OPENAPI.json
@@ -4158,6 +4158,10 @@
         "type": "object",
         "title": "DnsPostElementReq"
       },
+      "DnsServerId": {
+        "type": "integer",
+        "minimum": 0
+      },
       "DnsServerResolveResultResp": {
         "properties": {
           "server": {
@@ -4369,6 +4373,29 @@
             "title": "Existing domain ID",
             "examples": [
               123
+            ]
+          },
+          "dns_server_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DnsServerId"
+                },
+                "type": "array",
+                "minItems": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "DNS server IDs",
+            "description": "Use only specified DNS servers. If omitted, all configured DNS servers are used",
+            "examples": [
+              [
+                1,
+                2,
+                5
+              ]
             ]
           }
         },

--- a/models/http/domains_req.py
+++ b/models/http/domains_req.py
@@ -32,6 +32,8 @@ class DomainsPostElementReq(BaseModel):
     examples=['discord domain']
   )] = None
 
+type DnsServerId = Annotated[int, Field(ge=0)]
+
 class DomainResolveReq(BaseModel):
   domain: Annotated[Optional[str], Field(
     title='Domain name',
@@ -45,6 +47,12 @@ class DomainResolveReq(BaseModel):
     gt=0,
     examples=[123]
   )] = None
+  dns_server_ids: Annotated[Optional[list[DnsServerId]], Field(
+    title='DNS server IDs',
+    description='Use only specified DNS servers. If omitted, all configured DNS servers are used',
+    min_length=1,
+    examples=[[1, 2, 5]]
+  )] = None
 
   @field_validator('domain')
   @classmethod
@@ -55,6 +63,15 @@ class DomainResolveReq(BaseModel):
     if not domain:
       raise ValueError('Domain name must not be empty')
     return domain
+  
+  @field_validator('dns_server_ids')
+  @classmethod
+  def validate_dns_server_ids(cls, value: list[int] | None) -> list[int] | None:
+    if value is None:
+      return None
+    if len(value) != len(set(value)):
+      raise ValueError('DNS server IDs must be unique')
+    return value
   
   @model_validator(mode='after')
   def validate_resolve_source(self: Self) -> Self:

--- a/routers/domains_router.py
+++ b/routers/domains_router.py
@@ -10,13 +10,19 @@ from client.domains_resolving_client import DomainsResolver
 from .base_router import BaseRouter
 
 #
-from models.dto.domains_dto import CheckDomainResultDto, DomainResult
+from models.dto.domains_dto import CheckDomainResultDto
 # base
 from models.http.base import ErrorResp, NotFoundResp, NoDataResp, OkResp
 # request models
 from models.http.domains_req import DomainsQueryReq, DomainsSearchQueryReq, DomainsPostElementReq, DomainResolveReq
 # response models
-from models.http.domains_resp import DomainsPayloadResp, DomainElementResp, DomainResolveResp, DnsServerResolveResultResp
+from models.http.domains_resp import (
+  DomainsPayloadResp,
+  DomainElementResp,
+  DomainResolveResp,
+  DnsServerResolveResultResp
+)
+from models.http.dns_servers_resp import DnsElementResp
 
 class DomainsRouter(BaseRouter):
 
@@ -206,8 +212,27 @@ class DomainsRouter(BaseRouter):
           domain_name = domain_record.name
         if domain_name is None:
           raise ValueError('Domain name is not defined')
+        # DNS server
+        selected_dns_servers: List[DnsElementResp] | None = None
+        if data.dns_server_ids is not None:
+          selected_dns_servers = []
+          for dns_server_id in data.dns_server_ids:
+            dns_server: DnsElementResp | None =  await db.get_dns_server_on_id(id=dns_server_id)
+            if dns_server is None:
+              not_found_resp: NotFoundResp = NotFoundResp(
+                resolution=f"DNS server ID '{dns_server_id}' not found in local db"
+              )
+              return JSONResponse(
+                content=not_found_resp.to_dict(),
+                status_code=status.HTTP_404_NOT_FOUND
+              )
+            selected_dns_servers.append(dns_server)
+          logger.debug(f'DNS servers found on IDs={data.dns_server_ids} for single domain={domain_name} resolve')
         #
-        result: CheckDomainResultDto = await self.__domains_resolver.resolve_once(domain_name=domain_name)
+        result: CheckDomainResultDto = await self.__domains_resolver.resolve_once(
+          domain_name=domain_name,
+          selected_dns_servers=selected_dns_servers
+        )
         return_data: DomainResolveResp = DomainResolveResp(
           domain=result.domain,
           results=[


### PR DESCRIPTION
- Добавлен список DNS-серверов для точечного резолвинга
- Реализована проверка уникальности и существования переданных ID
- Сохранён обход всех DNS-серверов при отсутствии списка ID
- Поддержаны смешанные наборы classic DNS и DoH
- Обновлена OpenAPI-схема запроса