### PR TITLE
Интеграция RIPEstat для определения и кеширования IPv4-префиксов

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Available environment variables
 | `ROS_REST_API_DEFAULT_TIMEOUT` | float | `59.0` | Default timeout for RouterOS REST API requests |
 | `RIPE_STAT_BASE_URL` | str | `https://stat.ripe.net` | RIPEstat API base URL for IPv4 prefix lookups |
 | `RIPE_STAT_REQUESTS_SEMAPHORE_LIMIT` | int | `5` | Maximum number of concurrent RIPEstat prefix lookups during domain resolving |
+| `RIPE_STAT_CACHE_SIZE` | int | `10000` | Maximum number of RIPEstat prefix records in the in-memory cache |
+| `RIPE_STAT_PREFIX_CACHE_TTL_SEC` | int | `28800` | TTL in seconds for a RIPEstat result with a prefix |
+| `RIPE_STAT_EMPTY_PREFIX_CACHE_TTL_SEC` | int | `3600` | TTL in seconds for a RIPEstat result without a prefix |
+| `RIPE_STAT_CACHE_LOCK_TTL_SEC` | int | `120` | Maximum lifetime in seconds of a per-IP RIPEstat cache lock |
 
 ## MikroTik RouterOS
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Available environment variables
 | `DB_POOL_TIMEOUT` | int | `30` | Number of seconds to wait before giving up on getting a connection from the pool |
 | `DB_POOL_SIZE_OVERFLOW` | int | `2` | The number of connections to allow in connection pool `overflow`, that is connections that can be opened above and beyond the `db_pool_size` setting, which defaults to five |
 | `ATTEMPTS_LIMIT` | int | `5` | How many times a file must be checked with a negative result before it (and all its child entities) are deleted from the database |
+| `HTTPX_LOG_LEVEL` | str | `error` | HTTPX logging level |
 | `REQ_CONNECTION_RETRIES` | int | `3` | Requests will be retried the given number of times in case an `httpx.ConnectError` or an `httpx.ConnectTimeout` occurs, allowing smoother operation under flaky networks |
 | `REQ_TIMEOUT_DEFAULT` | float | `20.0` | General timeout for connections parameters `connect`, `read`, `write` or `pool` |
 | `REQ_TIMEOUT_CONNECT` | float | `20.0` | Individual timeout for `connect` |
@@ -89,6 +90,7 @@ Available environment variables
 | `REQ_MAX_CONNECTIONS` | int | `5` | The maximum number of allowable connections. `None` for no limits |
 | `REQ_MAX_KEEPALIVE_CONNECTIONS` | int | `30` | Number of allowable keep-alive connections. `None` to always allow |
 | `REQ_SSL_VERIFY` | bool | `True` | When making a request over HTTPS, HTTPX needs to verify the identity of the requested host. To do this, it uses a bundle of SSL certificates (a.k.a. CA bundle) delivered by a trusted certificate authority (CA). You can disable SSL verification completely and allow insecure requests |
+| `REQ_DEFAULT_LIMIT` | int | `100` | Maximum number of records returned by a paginated API request |
 | `DOMAINS_FILTERED_MIN_LEN` | int | `3` | The minimum domain length required to save it to the database. This is necessary to filter out empty domains that, for some reason, are generated in MikroTik scripts |
 | `DOMAINS_UPDATE_INTERVAL` | int | `172800` | Domain selection period. This means that if a domain has been processed, it will not be processed again until this period has passed. Specified in seconds. 172800s = 2days |
 | `DOMAINS_RESOLVE_SEMAPHORE_LIMIT` | int | `60` | Limit of concurrent domain resolving tasks |
@@ -96,8 +98,11 @@ Available environment variables
 | `DOMAINS_RESOLVE_STALE_BATCH_SIZE` | int | `2000` | Limit for sampling the number of previously processed domains |
 | `DOMAINS_BLACK_LIST` | str | `None` | Domains that should not be included in the database. Comma-separated list |
 | `LISTS_UPDATE_INTERVAL_SEC` | int | `604800` | The period after which the file must be uploaded and verified again. Specified in seconds. 604800s = 7days |
-| `IP_NOT_ALLOWED` | str | `127.0.0.1, 0.0.0.0, 0.0.0.0/0, ::, ::/0` | A list of IP addresses that should not be included in the database. Comma-separated list. |
+| `IP_NOT_ALLOWED` | str | `0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.2.0/24, 192.88.99.0/24, 192.168.0.0/16, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 240.0.0.0/4, ::/128, ::1/128, fc00::/7, fe80::/10, ff00::/8, 2001:db8::/32` | Comma-separated CIDR networks that must not be saved in the database. |
 | `ROS_REST_API_READ_TIMEOUT` | float | `59.0` | ROS REST API server timeout = 60s |
+| `ROS_REST_API_DEFAULT_TIMEOUT` | float | `59.0` | Default timeout for RouterOS REST API requests |
+| `RIPE_STAT_BASE_URL` | str | `https://stat.ripe.net` | RIPEstat API base URL for IPv4 prefix lookups |
+| `RIPE_STAT_REQUESTS_SEMAPHORE_LIMIT` | int | `5` | Maximum number of concurrent RIPEstat prefix lookups during domain resolving |
 
 ## MikroTik RouterOS
 

--- a/cache/cache.py
+++ b/cache/cache.py
@@ -4,6 +4,7 @@ from enum import StrEnum
 from typing import Any, Self
 
 from logger.logger import logger
+from config.config import settings
 
 class Jobs(StrEnum):
   LISTS_LOAD            = 'lists_load'
@@ -50,7 +51,14 @@ class Cache():
   async def set(self: Self, key: str, value: Any, expire: float | None = None) -> None:
     await self.update(key=key, value=value, expire=expire)
 
+  def lock(self: Self, key: str, expire: float, wait: bool = True) -> Any:
+    return self.cache.lock(key=key, expire=expire, wait=wait)
+
 try:
   jobs_cache: Cache = Cache('jobs_cache')
+  ripe_stat_cache: Cache = Cache(
+    'ripe_stat_cache',
+    size=settings.ripe_stat_cache_size
+  )
 except Exception as err:
   raise err

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -18,7 +18,16 @@ from dns.message import QueryMessage, make_query, from_wire
 from dns.rrset import RRset
 from itertools import product
 from base64 import urlsafe_b64encode
-from httpx import AsyncClient, Response, ConnectTimeout, ReadError, RemoteProtocolError, ConnectError
+from ipaddress import IPv4Address, IPv4Network, ip_address, ip_network
+from httpx import (
+  AsyncClient,
+  Response,
+  ConnectTimeout,
+  ReadError,
+  RemoteProtocolError,
+  ConnectError,
+  HTTPError
+)
 from types import CoroutineType
 from typing import Self, List, Tuple, Dict, Literal
 
@@ -27,7 +36,8 @@ from config.config import settings
 from cache.cache import jobs_cache, Jobs
 from database.db import db
 from client.http_base_client import HttpClient
-from utils.utils import get_ip_version
+from client.ripe_stat_client import RipeStatClient, RipeStatClientError
+from utils.utils import get_ip_network_address, get_ip_version
 
 from models.http.domains_req import DomainsPostElementReq
 from models.http.domains_resp import DomainElementResp
@@ -48,6 +58,11 @@ class DomainsResolver:
   __semaphore: Semaphore = Semaphore(settings.domains_resolve_semaphore_limit)
 
   __http_client: AsyncClient = HttpClient.get_client('domains_resolver')
+
+  __ripe_stat_client: RipeStatClient = RipeStatClient()
+  __ripe_stat_semaphore: Semaphore = Semaphore(
+    settings.ripe_stat_requests_semaphore_limit
+  )
 
   domains_resolve_queue: Queue[DomainResult] = Queue(maxsize=settings.queue_max_size)
 
@@ -337,26 +352,149 @@ class DomainsResolver:
 
   # IPS
 
-  async def __ips_processing(self: Self, domain: DomainResult, current_ips: List[IpRecordDto]) -> None:
+  @staticmethod
+  def __get_current_cidr_for_resolved_ip(
+    resolved_ip: str,
+    current_ip_records: List[IpRecordDto]
+  ) -> str | None:
+    for record in current_ip_records:
+      if '/' not in record.ip_address:
+        continue
+      if get_ip_network_address(record.ip_address) == resolved_ip:
+        return record.ip_address
+    return None
+
+  async def __get_ip_address_for_storage(
+    self: Self,
+    resolved_ip: str,
+    current_ip_records: List[IpRecordDto]
+  ) -> str:
+    parsed_ip = ip_address(resolved_ip)
+
+    if not isinstance(parsed_ip, IPv4Address) or not parsed_ip.is_global:
+      return resolved_ip
+
+    if parsed_ip.packed[-1] != 0:
+      return resolved_ip
+
+    try:
+      async with self.__ripe_stat_semaphore:
+        ripe_result = await self.__ripe_stat_client.get_prefix(
+          address=resolved_ip
+        )
+
+      if ripe_result.prefix is None:
+        logger.debug(
+          f'RIPEstat prefix not found for {resolved_ip}; keep host route'
+        )
+        return resolved_ip
+
+      network = ip_network(ripe_result.prefix, strict=True)
+
+      if (
+        not isinstance(network, IPv4Network)
+        or network.prefixlen == 32
+        or network.network_address != parsed_ip
+      ):
+        logger.debug(
+          f'RIPEstat prefix rejected for {resolved_ip}: '
+          f'{ripe_result.prefix}'
+        )
+        return resolved_ip
+
+      storage_ip = str(network)
+      logger.debug(
+        f'RIPEstat prefix accepted for {resolved_ip}: {storage_ip}'
+      )
+      return storage_ip
+    except (RipeStatClientError, HTTPError, ValueError) as err:
+      current_cidr = self.__get_current_cidr_for_resolved_ip(
+        resolved_ip=resolved_ip,
+        current_ip_records=current_ip_records
+      )
+
+      if current_cidr is not None:
+        logger.warning(
+          f'RIPEstat prefix lookup failed for {resolved_ip}: '
+          f'[{err.__class__.__name__}] {err}; '
+          f'keep stored prefix {current_cidr}'
+        )
+        return current_cidr
+
+      logger.warning(
+        f'RIPEstat prefix lookup failed for {resolved_ip}: '
+        f'[{err.__class__.__name__}] {err}; keep host route'
+      )
+      return resolved_ip
+
+  async def __ips_processing(
+    self: Self,
+    domain: DomainResult,
+    current_ips: List[IpRecordDto]
+  ) -> None:
     logger.debug(f'IP prepare for {domain.name}')
     logger.debug(f'{domain=}, {current_ips=}')
     try:
-      current_ips_list: List[str] = [record.ip_address for record in current_ips]
-      resolved_ips: List[str] = []
-      new_ips: list[IpRecordDto] = []
-      remove_ips: list[IpRecordDto] = []
-      for ipv4 in domain.result.A:
-        resolved_ips.append(ipv4)
-      for ipv6 in domain.result.AAAA:
-        resolved_ips.append(ipv6)
-      # 1. Add new to DB
-      new_ips = [
-        IpRecordDto(ip_address=ip, addr_type=get_ip_version(ip))
-        for ip in resolved_ips
-        if ip not in current_ips_list
-      ]
-      # 2. Remove from DB
-      remove_ips = [record for record in current_ips if record.ip_address not in resolved_ips]
+      resolved_ips: List[str] = list(dict.fromkeys(
+        domain.result.A + domain.result.AAAA
+      ))
+      current_ips_by_network_address: Dict[str, List[IpRecordDto]] = {}
+      desired_ips_by_network_address: Dict[str, IpRecordDto] = {}
+      new_ips: List[IpRecordDto] = []
+      remove_ips: List[IpRecordDto] = []
+
+      for record in current_ips:
+        network_address = get_ip_network_address(record.ip_address)
+        if network_address not in current_ips_by_network_address:
+          current_ips_by_network_address[network_address] = []
+        current_ips_by_network_address[network_address].append(record)
+
+      for resolved_ip in resolved_ips:
+        current_ip_records = current_ips_by_network_address.get(
+          resolved_ip,
+          []
+        )
+        storage_ip = await self.__get_ip_address_for_storage(
+          resolved_ip=resolved_ip,
+          current_ip_records=current_ip_records
+        )
+        network_address = get_ip_network_address(storage_ip)
+
+        if network_address != resolved_ip:
+          logger.warning(
+            f'Invalid storage address for {resolved_ip}: {storage_ip}; '
+            f'keep original IP'
+          )
+          storage_ip = resolved_ip
+          network_address = resolved_ip
+
+        desired_ips_by_network_address[network_address] = IpRecordDto(
+          ip_address=storage_ip,
+          addr_type=get_ip_version(storage_ip)
+        )
+
+      for network_address, desired_ip in desired_ips_by_network_address.items():
+        current_ip_records = current_ips_by_network_address.pop(
+          network_address,
+          []
+        )
+        is_current_value_present = False
+
+        for current_ip in current_ip_records:
+          if (
+            not is_current_value_present
+            and current_ip.ip_address == desired_ip.ip_address
+          ):
+            is_current_value_present = True
+            continue
+          remove_ips.append(current_ip)
+
+        if not is_current_value_present:
+          new_ips.append(desired_ip)
+
+      for stale_ip_records in current_ips_by_network_address.values():
+        remove_ips.extend(stale_ip_records)
+
       if len(new_ips) > 0:
         domain.append_ips_to_insert(ips=new_ips)
       if len(remove_ips) > 0:

--- a/client/ripe_stat_client.py
+++ b/client/ripe_stat_client.py
@@ -1,0 +1,73 @@
+from ipaddress import ip_address
+from typing import Any, Dict, Self
+
+from httpx import AsyncClient, Response
+
+from client.http_base_client import HttpClient
+from config.config import settings
+from models.dto.ripe_stat_dto import RipeStatAddressPrefixDto
+
+
+class RipeStatClientError(Exception):
+  pass
+
+
+class RipeStatClient:
+
+  __client: AsyncClient = HttpClient.get_client('ripe_stat')
+
+  def __init__(self: Self) -> None:
+    self.__base_url: str = settings.ripe_stat_base_url.rstrip('/')
+
+  async def get_prefix(self: Self, address: str) -> RipeStatAddressPrefixDto:
+    normalized_address: str = str(ip_address(address))
+
+    response: Response = await self.__client.get(
+      url=f'{self.__base_url}/data/network-info/data.json',
+      params={'resource': normalized_address},
+      headers={'Accept': 'application/json'}
+    )
+
+    payload: Dict[str, Any] = self.__get_payload(response=response)
+
+    if not response.is_success or payload.get('status') != 'ok':
+      message: str = str(payload.get('message', response.reason_phrase))
+      raise RipeStatClientError(
+        f'RIPEstat network-info error for {normalized_address}: '
+        f'{message} (HTTP {response.status_code})'
+      )
+
+    data: Any = payload.get('data')
+
+    if not isinstance(data, dict):
+      raise RipeStatClientError(
+        f'RIPEstat network-info returned invalid data for {normalized_address}'
+      )
+
+    prefix: Any = data.get('prefix')
+
+    if prefix is not None and not isinstance(prefix, str):
+      raise RipeStatClientError(
+        f'RIPEstat network-info returned invalid prefix for {normalized_address}'
+      )
+
+    return RipeStatAddressPrefixDto(
+      address=normalized_address,
+      prefix=prefix
+    )
+
+  @staticmethod
+  def __get_payload(response: Response) -> Dict[str, Any]:
+    try:
+      payload: Any = response.json()
+    except ValueError as err:
+      raise RipeStatClientError(
+        f'RIPEstat returned invalid JSON (HTTP {response.status_code})'
+      ) from err
+
+    if not isinstance(payload, dict):
+      raise RipeStatClientError(
+        f'RIPEstat returned JSON instead of object (HTTP {response.status_code})'
+      )
+
+    return payload

--- a/client/ripe_stat_client.py
+++ b/client/ripe_stat_client.py
@@ -3,8 +3,10 @@ from typing import Any, Dict, Self
 
 from httpx import AsyncClient, Response
 
+from cache.cache import ripe_stat_cache
 from client.http_base_client import HttpClient
 from config.config import settings
+from logger.logger import logger
 from models.dto.ripe_stat_dto import RipeStatAddressPrefixDto
 
 
@@ -21,10 +23,48 @@ class RipeStatClient:
 
   async def get_prefix(self: Self, address: str) -> RipeStatAddressPrefixDto:
     normalized_address: str = str(ip_address(address))
+    cache_key: str = f'prefix:{normalized_address}'
 
+    cached_result = await self.__get_cached_prefix(
+      address=normalized_address,
+      cache_key=cache_key
+    )
+    if cached_result is not None:
+      return cached_result
+
+    async with ripe_stat_cache.lock(
+      key=f'lock:{cache_key}',
+      expire=settings.ripe_stat_cache_lock_ttl_sec
+    ):
+      cached_result = await self.__get_cached_prefix(
+        address=normalized_address,
+        cache_key=cache_key
+      )
+      if cached_result is not None:
+        return cached_result
+
+      result = await self.__get_prefix_from_ripe_stat(
+        address=normalized_address
+      )
+      cache_ttl = (
+        settings.ripe_stat_prefix_cache_ttl_sec
+        if result.prefix is not None
+        else settings.ripe_stat_empty_prefix_cache_ttl_sec
+      )
+      await ripe_stat_cache.set(
+        key=cache_key,
+        value=result.prefix or '',
+        expire=cache_ttl
+      )
+      return result
+
+  async def __get_prefix_from_ripe_stat(
+    self: Self,
+    address: str
+  ) -> RipeStatAddressPrefixDto:
     response: Response = await self.__client.get(
       url=f'{self.__base_url}/data/network-info/data.json',
-      params={'resource': normalized_address},
+      params={'resource': address},
       headers={'Accept': 'application/json'}
     )
 
@@ -33,7 +73,7 @@ class RipeStatClient:
     if not response.is_success or payload.get('status') != 'ok':
       message: str = str(payload.get('message', response.reason_phrase))
       raise RipeStatClientError(
-        f'RIPEstat network-info error for {normalized_address}: '
+        f'RIPEstat network-info error for {address}: '
         f'{message} (HTTP {response.status_code})'
       )
 
@@ -41,19 +81,38 @@ class RipeStatClient:
 
     if not isinstance(data, dict):
       raise RipeStatClientError(
-        f'RIPEstat network-info returned invalid data for {normalized_address}'
+        f'RIPEstat network-info returned invalid data for {address}'
       )
 
     prefix: Any = data.get('prefix')
 
     if prefix is not None and not isinstance(prefix, str):
       raise RipeStatClientError(
-        f'RIPEstat network-info returned invalid prefix for {normalized_address}'
+        f'RIPEstat network-info returned invalid prefix for {address}'
       )
 
+    return RipeStatAddressPrefixDto(address=address, prefix=prefix)
+
+  @staticmethod
+  async def __get_cached_prefix(
+    address: str,
+    cache_key: str
+  ) -> RipeStatAddressPrefixDto | None:
+    if not await ripe_stat_cache.exists(cache_key):
+      return None
+
+    cached_prefix = await ripe_stat_cache.get(cache_key)
+
+    if not isinstance(cached_prefix, str):
+      logger.warning(
+        f'Invalid RIPEstat cache value for {address}; refresh from RIPEstat'
+      )
+      return None
+
+    logger.debug(f'RIPEstat cache hit for {address}')
     return RipeStatAddressPrefixDto(
-      address=normalized_address,
-      prefix=prefix
+      address=address,
+      prefix=cached_prefix or None
     )
 
   @staticmethod

--- a/config/config.py
+++ b/config/config.py
@@ -89,6 +89,10 @@ class Settings(BaseSettings):
   # RIPE
   ripe_stat_base_url: str = Field(default='https://stat.ripe.net')
   ripe_stat_requests_semaphore_limit: int = Field(default=5)
+  ripe_stat_cache_size: int = Field(default=10000)
+  ripe_stat_prefix_cache_ttl_sec: int = Field(default=28800)
+  ripe_stat_empty_prefix_cache_ttl_sec: int = Field(default=3600)
+  ripe_stat_cache_lock_ttl_sec: int = Field(default=120)
 
   @computed_field
   @property

--- a/config/config.py
+++ b/config/config.py
@@ -78,6 +78,9 @@ class Settings(BaseSettings):
   # ROUTEROS section
   ros_rest_api_read_timeout: float = Field(default=59.0) # ROS REST API server read timeout = 60s
   ros_rest_api_default_timeout: float = Field(default=59.0) # ROS REST API server base default timeout = 60s
+  # RIPE
+  ripe_stat_base_url: str = Field(default='https://stat.ripe.net')
+  ripe_stat_requests_semaphore_limit: int = Field(default=5)
 
   @computed_field
   @property

--- a/config/config.py
+++ b/config/config.py
@@ -1,5 +1,6 @@
 from os import getcwd
 from os.path import normpath, join
+from ipaddress import IPv4Network, IPv6Network, ip_network
 from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pathlib import Path
@@ -74,7 +75,14 @@ class Settings(BaseSettings):
   # Lists section
   lists_update_interval_sec: int = Field(default=604800) # default 7 days
   # IP address section
-  ip_not_allowed: str = Field(default='127.0.0.1, 0.0.0.0, 0.0.0.0/0, ::, ::/0')
+  ip_not_allowed: str = Field(default=(
+    '0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, '
+    '169.254.0.0/16, 172.16.0.0/12, 192.0.2.0/24, '
+    '192.88.99.0/24, 192.168.0.0/16, 198.18.0.0/15, '
+    '198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, '
+    '240.0.0.0/4, ::/128, ::1/128, fc00::/7, fe80::/10, '
+    'ff00::/8, 2001:db8::/32'
+  ))
   # ROUTEROS section
   ros_rest_api_read_timeout: float = Field(default=59.0) # ROS REST API server read timeout = 60s
   ros_rest_api_default_timeout: float = Field(default=59.0) # ROS REST API server base default timeout = 60s
@@ -96,7 +104,14 @@ class Settings(BaseSettings):
   @computed_field
   @property
   def ip_not_allowed_list(self: Self) -> List[str]:
-    return self.ip_not_allowed.split(',')
+    return [value.strip() for value in self.ip_not_allowed.split(',') if value.strip()]
+
+  @property
+  def ip_not_allowed_networks(self: Self) -> List[IPv4Network | IPv6Network]:
+    return [
+      ip_network(value, strict=False)
+      for value in self.ip_not_allowed_list
+    ]
 
   @computed_field
   @property

--- a/database/db.py
+++ b/database/db.py
@@ -3,6 +3,7 @@ from asyncio import (
   sleep,
   wait_for,
   create_task,
+  to_thread,
   Queue,
   QueueFull,
   TimeoutError,
@@ -35,7 +36,7 @@ from config.config import settings
 from logger.logger import logger, Logger
 from client.file_loader_client import FileLoaderClient
 
-from utils.utils import get_ip_version, calculate_checksum
+from utils.utils import check_ip_allow, get_ip_version, calculate_checksum
 
 from models.db.dns_servers_dbo import DnsServersDbo
 from models.db.domains_lists_dbo import DomainsListsDbo
@@ -1142,6 +1143,37 @@ class DataBase:
     finally:
       await db_session.close()
 
+  async def get_not_allowed_ip_record_ids(self: Self) -> List[int]:
+    logger.debug('Try get IP address records blocked by IP_NOT_ALLOWED ...')
+    db_session: AsyncSession | None = None
+    try:
+      db_session = await self.__read_connect()
+      ip_records: Sequence[Row[Tuple[int, str]]] = \
+        await IpRecordsDbo.get_all_ids_and_addresses(db_session=db_session)
+      result = await to_thread(
+        lambda: [
+          record[0]
+          for record in ip_records
+          if not check_ip_allow(record[1])
+        ]
+      )
+      logger.debug(
+        f'IP address records blocked by IP_NOT_ALLOWED: {len(result)}'
+      )
+      return result
+    except Exception as err:
+      logger.error(
+        'Try get IP address records blocked by IP_NOT_ALLOWED failed : '
+        f'{err}',
+        exc_info=True
+      )
+      if db_session is not None:
+        await db_session.rollback()
+      raise err
+    finally:
+      if db_session is not None:
+        await db_session.close()
+
   async def put_add_ips_to_queue(self: Self, ips: List[IpsPostElementReq]) -> None:
     logger.debug(f'Try send Ips to Queue ...')
     try:
@@ -1194,6 +1226,51 @@ class DataBase:
       logger.error(f'Queue is full for try send deleted Domains to Queue')
     except Exception as err:
       logger.error(f'Unexpected error - Try send deleted Domains to Queue : {err}', exc_info=True)
+
+  async def put_delete_ip_records_to_queue(self: Self, ids: List[int]) -> bool:
+    logger.debug('Try send IP address records for deletion to Queue ...')
+    if len(ids) < 1:
+      return True
+    if self.db_save_queue.full():
+      logger.error('Queue is full for IP address records deletion')
+      return False
+    try:
+      ips_element: QueueElementDto = QueueElementDto(
+        target=TargetAction.IPS_DELETE_ID,
+        elements=ids
+      )
+      logger.debug(
+        f'Put IP address records for deletion to Queue: {len(ids)}'
+      )
+      self.db_save_queue.put_nowait(item=ips_element)
+      return True
+    except QueueFull:
+      logger.error('Queue is full for IP address records deletion')
+      return False
+    except Exception as err:
+      logger.error(
+        'Unexpected error - Try send IP address records for deletion to '
+        f'Queue : {err}',
+        exc_info=True
+      )
+      return False
+
+  async def cleanup_not_allowed_ip_records(self: Self) -> None:
+    logger.debug('Start cleanup of IP address records blocked by IP_NOT_ALLOWED')
+    try:
+      ids: List[int] = await self.get_not_allowed_ip_record_ids()
+      is_queued: bool = await self.put_delete_ip_records_to_queue(ids)
+      if is_queued:
+        logger.info(
+          'IP address records blocked by IP_NOT_ALLOWED queued for '
+          f'deletion: {len(ids)}'
+        )
+    except Exception as err:
+      logger.error(
+        'Cleanup of IP address records blocked by IP_NOT_ALLOWED failed : '
+        f'{err}',
+        exc_info=True
+      )
 
   async def get_all_ips_for_domain(self: Self, domain_id: int) -> List[IpRecordDto]:
     logger.debug(f'Try get all IP address records for Domain {domain_id=} ...')

--- a/models/db/ip_records_dbo.py
+++ b/models/db/ip_records_dbo.py
@@ -185,6 +185,21 @@ class IpRecordsDbo(Dbo):
       raise err
 
   @classmethod
+  async def get_all_ids_and_addresses(
+    cls: type[Self],
+    db_session: AsyncSession
+  ) -> Sequence[Row[Tuple[int, str]]]:
+    try:
+      select_stmt: Select[Tuple[int, str]] = select(
+        cls.id,
+        cls.ip_address
+      ).order_by(cls.id)
+      result: Result[Tuple[int, str]] = await db_session.execute(select_stmt)
+      return result.fetchall()
+    except Exception as err:
+      raise err
+
+  @classmethod
   async def get_ips_on_domain_id_extend(
     cls: type[Self],
     db_session: AsyncSession,

--- a/models/dto/ripe_stat_dto.py
+++ b/models/dto/ripe_stat_dto.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class RipeStatAddressPrefixDto:
+  address: str
+  prefix: str | None = None

--- a/models/http/ripe_stat_req.py
+++ b/models/http/ripe_stat_req.py
@@ -1,0 +1,39 @@
+from ipaddress import IPv4Address, ip_address
+from pydantic import BaseModel, Field, field_validator, model_validator
+from typing import Annotated, Self
+
+
+class RipeStatPrefixCheckReq(BaseModel):
+  address: Annotated[str | None, Field(
+    title='IPv4 address',
+    description='IPv4 address to check in RIPEstat without saving it to the database',
+    examples=['8.6.112.0']
+  )] = None
+  id: Annotated[int | None, Field(
+    title='Existing IP address record ID',
+    description='Use an existing IP address record from the local database without changing it',
+    gt=0,
+    examples=[55369745]
+  )] = None
+
+  @field_validator('address')
+  @classmethod
+  def validate_address(cls, value: str | None) -> str | None:
+    if value is None:
+      return None
+
+    try:
+      parsed_address = ip_address(value.strip())
+    except ValueError:
+      raise ValueError('Invalid IPv4 address')
+
+    if not isinstance(parsed_address, IPv4Address):
+      raise ValueError('Only IPv4 addresses are supported by this check')
+
+    return str(parsed_address)
+
+  @model_validator(mode='after')
+  def validate_check_source(self: Self) -> Self:
+    if (self.address is None) == (self.id is None):
+      raise ValueError('Specify exactly one of "address" or "id"')
+    return self

--- a/models/http/ripe_stat_resp.py
+++ b/models/http/ripe_stat_resp.py
@@ -1,0 +1,6 @@
+from .base import Base
+
+
+class RipeStatPrefixCheckResp(Base):
+  address: str
+  prefix: str | None = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,26 +18,26 @@ docs = ["sphinx (==8.1.3)", "sphinx-mdinclude (==0.6.2)"]
 
 [[package]]
 name = "annotated-doc"
-version = "0.0.4"
+version = "0.0.5"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
-    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+    {file = "annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101"},
+    {file = "annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb"},
 ]
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
-    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+    {file = "annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0"},
+    {file = "annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"},
 ]
 
 [[package]]
@@ -80,14 +80,14 @@ tests = ["hypothesis (==6.148.7)", "pytest (==9.0.2)", "pytest-asyncio (==1.3.0)
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
-    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
+    {file = "certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"},
+    {file = "certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"},
 ]
 
 [[package]]
@@ -141,14 +141,14 @@ wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
 
 [[package]]
 name = "fastapi"
-version = "0.139.2"
+version = "0.140.13"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c"},
-    {file = "fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e"},
+    {file = "fastapi-0.140.13-py3-none-any.whl", hash = "sha256:8b017110e1e9f30a95e8bdb8f71fbe2f0fe3af5717109e5b14f9e069df54f6d4"},
+    {file = "fastapi-0.140.13.tar.gz", hash = "sha256:500172a08cf1459901f90b05c37d93060dada3b573fec8f0862445db52ba6b4b"},
 ]
 
 [package.dependencies]
@@ -165,92 +165,92 @@ standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[stand
 
 [[package]]
 name = "greenlet"
-version = "3.5.3"
+version = "3.5.4"
 description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
 files = [
-    {file = "greenlet-3.5.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c180d22d325fb613956b443c3c6f4406eb70e6defc70d3974da2a7b59e06f48c"},
-    {file = "greenlet-3.5.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483d08c11181c83a6ce1a7a61df0f624a208ec40817a3bb2302714592eee4f04"},
-    {file = "greenlet-3.5.3-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1dae6e0091eae084317e411f047f0b7cb241c6db570f7c45fd6b900a274914ce"},
-    {file = "greenlet-3.5.3-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0f6ff50ff8dbd51fae9b37f4101648b04ea0df19b3f50ab2beb5061e7716a5c8"},
-    {file = "greenlet-3.5.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcd2d72ccd70a1ec68ba6ef93e7fbb4420ef9997dabc7010d893bd4015e0bec"},
-    {file = "greenlet-3.5.3-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:37bf9c538f5ae6e63d643f88dec37c0c83bdf0e2ebc62961dedcf458822f7b71"},
-    {file = "greenlet-3.5.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:73f152c895e09907e0dbe24f6c2db37beb085cd63db91c3825a0fcd0064124a8"},
-    {file = "greenlet-3.5.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8bdb43e1a1d1873721acab2be99c5befd4d2044ddfd52e4d610801019880a702"},
-    {file = "greenlet-3.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:0909f9355a9f24845d3299f3112e266a06afb68302041989fd26bd68894933db"},
-    {file = "greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4"},
-    {file = "greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc"},
-    {file = "greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6"},
-    {file = "greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb"},
-    {file = "greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7"},
-    {file = "greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c"},
-    {file = "greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8"},
-    {file = "greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8"},
-    {file = "greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7"},
-    {file = "greenlet-3.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:ec6f1af59f6b5f3fc9678e2ea062d8377d22ac644f7844cb7a292910cf12ff44"},
-    {file = "greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2"},
-    {file = "greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b"},
-    {file = "greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab"},
-    {file = "greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23"},
-    {file = "greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861"},
-    {file = "greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c"},
-    {file = "greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149"},
-    {file = "greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea"},
-    {file = "greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c"},
-    {file = "greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d"},
-    {file = "greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550"},
-    {file = "greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5"},
-    {file = "greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3"},
-    {file = "greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1"},
-    {file = "greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a"},
-    {file = "greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda"},
-    {file = "greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb"},
-    {file = "greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b"},
-    {file = "greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b"},
-    {file = "greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4"},
-    {file = "greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117"},
-    {file = "greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8"},
-    {file = "greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d"},
-    {file = "greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814"},
-    {file = "greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c"},
-    {file = "greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260"},
-    {file = "greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a"},
-    {file = "greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154"},
-    {file = "greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e"},
-    {file = "greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605"},
-    {file = "greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be"},
-    {file = "greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310"},
-    {file = "greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8"},
-    {file = "greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d"},
-    {file = "greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f"},
-    {file = "greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0"},
-    {file = "greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21"},
-    {file = "greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da"},
-    {file = "greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3"},
-    {file = "greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc"},
-    {file = "greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47"},
-    {file = "greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81"},
-    {file = "greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357"},
-    {file = "greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d"},
-    {file = "greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128"},
-    {file = "greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34"},
-    {file = "greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b"},
-    {file = "greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930"},
-    {file = "greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227"},
-    {file = "greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c"},
-    {file = "greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f"},
-    {file = "greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2"},
-    {file = "greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91"},
-    {file = "greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608"},
-    {file = "greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d"},
-    {file = "greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb"},
-    {file = "greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16"},
-    {file = "greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf"},
-    {file = "greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31"},
-    {file = "greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1"},
+    {file = "greenlet-3.5.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:ac5bf81d79d2c8eeb2ef6359b2e1687a1e9ebf46c2b1f970da9a9255df51d190"},
+    {file = "greenlet-3.5.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89f3738167bab8c1084b94e23023d41d247117ac149fa0fbcb5bd4cf6262b353"},
+    {file = "greenlet-3.5.4-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e9a5e3406e3ed8125ae1a3b37c12f3434e2b1f0fa053197c5557895b4fb09606"},
+    {file = "greenlet-3.5.4-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a2d614cb2372c7101a12ea8b96dd56f81c986d247c5a73db67063f3ed1ca4a52"},
+    {file = "greenlet-3.5.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ab9f0704bccf6d3b38e0d2130b7b33271cff11453690da074fa280c3aa8e8e7"},
+    {file = "greenlet-3.5.4-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:188e4d142f243051d92a1f5c244a741da02dddc070a0620c842804d7b56d008c"},
+    {file = "greenlet-3.5.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2cdaadc3d31445a8f782bde3cd37e49a2c2a9c6da6daf76a3e34c683b271a3c7"},
+    {file = "greenlet-3.5.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:70bdfacdc183dac838b2a0aaff2dd6134a457c52fe68a9c6bbab435483d2b9df"},
+    {file = "greenlet-3.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:69173331fbc5d64bfac0065d7e22c39cfcd089e9b18d125bdcd5079363b09616"},
+    {file = "greenlet-3.5.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e883de250e299654b1f1680f72a1a9f9ba62c9bd1bce84099c90657349a8dfbb"},
+    {file = "greenlet-3.5.4-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32802705c2c1ff25e8237b3bdacf2594fa02be80af8a66703eb7853ea7e68686"},
+    {file = "greenlet-3.5.4-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57aa201b351f7c7c75627c60d29e4d5b97a07d37efeb62b903466fca42c097d7"},
+    {file = "greenlet-3.5.4-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9667862a2e38ad379f11b845daeda22c8989186def44f06962c9c4c05e556da7"},
+    {file = "greenlet-3.5.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3fe76c2cac86b4f7a1e92865ac0a54384deb05c92986287c1a7110d9bd53071"},
+    {file = "greenlet-3.5.4-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:ae53534b5dec0f4c2ec26f898f538dc8ea1ca3ef2927d597a9439e40a09da937"},
+    {file = "greenlet-3.5.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1e1a4a684b16c45ba324e60b32a4386a87722bcb815d2a149d2182f9b401ca72"},
+    {file = "greenlet-3.5.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e849e6e139b9671adeac505f72fc05f4af7fd1921faef40295e214fc3b361b59"},
+    {file = "greenlet-3.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:dc418cf4c873357964d6624445ed09472e50def990c65dd4e76fc3ba8cd9cef6"},
+    {file = "greenlet-3.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:c38c902a0986eba1f6e7ba1ab39ad5195926abde90f3fe080e08212db62176da"},
+    {file = "greenlet-3.5.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3d66250e8b09f182ede05490998c818b5961f7a3640332d44c4927caec7bbfe4"},
+    {file = "greenlet-3.5.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90e930c9c192e5b3ee9fb8bcd920ea3926155e2e3ded39fc697323addecee17"},
+    {file = "greenlet-3.5.4-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:791fdfeeb9c6e0c7b10fa151bf110d2a6974866f13dcb5b1c7efae698245893a"},
+    {file = "greenlet-3.5.4-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b7c895310363f310361e0fe2072af85269d2a2a285cd04c0c59e79a5e3670dcf"},
+    {file = "greenlet-3.5.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88193799d43dbf8c8a806d6405c9c52fe2af40bf75072a606357b33cc336c7f"},
+    {file = "greenlet-3.5.4-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:13b980043cb1b3134e81ea469da1250ddcc6bfe6d245bbaa59168d9cdc8f228f"},
+    {file = "greenlet-3.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7a5f095767c4493afcd06067f2bb3b8716e3f3f9e92b99c88e7e99f885b3d4d"},
+    {file = "greenlet-3.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42afdc1ab5f66da8c586c32af9224a74a706b4f0ea0dc3a4188a0860a09c65c9"},
+    {file = "greenlet-3.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3"},
+    {file = "greenlet-3.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:77d6ce04fed0d9aeed42e0f37923cc43eba9b027bdd9c34546bb4ccd143d0fe0"},
+    {file = "greenlet-3.5.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:24e61b88cb7e1b1d794b32a10cc346ac779681d6d74ff137a3e0a444d2bf1f02"},
+    {file = "greenlet-3.5.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:870d730fec833f5a06906a32596cc099b9161594642a92a520b7a88911c95356"},
+    {file = "greenlet-3.5.4-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec5ff0d1878df6af3bf9b638a5a92a7d5693291de77c91bff10fa48519c604ef"},
+    {file = "greenlet-3.5.4-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07bd44616608d873d06735b63ef1a88191d6ca57c8d291d6559c71bc14c0893c"},
+    {file = "greenlet-3.5.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d84d993f6e575c950d91a23c1345d18fe1a4310d447bf630849d7809196b52f0"},
+    {file = "greenlet-3.5.4-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:3529a8a933582ad19e224792cac7372489526576b75b4c124e8e4f29948f4861"},
+    {file = "greenlet-3.5.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:58023945f421093de5e6fa108c0985a8659d43f49e0216da25099369a121bcbd"},
+    {file = "greenlet-3.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bae2728e1897aa8df8cb1af38cd48b3a743aefe29372de7b8b7a9f532501e69f"},
+    {file = "greenlet-3.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:ca5726c0b08ca35ae873557266a78b2c3f3b2b7d7401aa5ff886c2045dd0111c"},
+    {file = "greenlet-3.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:7c1303791d603080cac6fc3b34df51c3b75b723739c282c8029e48a0d241672f"},
+    {file = "greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22"},
+    {file = "greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf"},
+    {file = "greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9"},
+    {file = "greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c"},
+    {file = "greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8"},
+    {file = "greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c"},
+    {file = "greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3"},
+    {file = "greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec"},
+    {file = "greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c"},
+    {file = "greenlet-3.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:f260930bbbbcf9caee661211235a5111c86dfe5832fdf6ae4570da1e0995320f"},
+    {file = "greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3"},
+    {file = "greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867"},
+    {file = "greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c"},
+    {file = "greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8"},
+    {file = "greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66"},
+    {file = "greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd"},
+    {file = "greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7"},
+    {file = "greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e"},
+    {file = "greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132"},
+    {file = "greenlet-3.5.4-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:178111881dd7a6c946471fda85485ec796e1043c2b939f694b096e2ecf986809"},
+    {file = "greenlet-3.5.4-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d92df08dd65fede97fc37aad36c2e9dcda3b31c467f8e0c2c096456cb818e927"},
+    {file = "greenlet-3.5.4-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:99e8f8c4ebc4fd80aa26c1280ae9ad43a0976e786349703a181cf0bae60413e5"},
+    {file = "greenlet-3.5.4-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1f17e362d78e37559e0506c5a7d066bdd45073c36a0127a543e8a0df27242ff3"},
+    {file = "greenlet-3.5.4-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:394de08dad5ffcb1f50c2159d93e398d9d2da3ed437645eaa54771fa720db9f0"},
+    {file = "greenlet-3.5.4-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:cd320d998cbaa032932830448e39abf3c6a12901295e386e8114db926e10cffb"},
+    {file = "greenlet-3.5.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:c883d61f2282d72c767a14936641b3efcbde9d82f1080712aaea0b1d3126cb88"},
+    {file = "greenlet-3.5.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2a924f15d17957e252a810acefcb5942f5ca712298e8b6fcaed9a307d357522c"},
+    {file = "greenlet-3.5.4-cp315-cp315-win_amd64.whl", hash = "sha256:ed17e5f3420360d5b459de8462efb52060399a5326a613d4cde31cef63ef95da"},
+    {file = "greenlet-3.5.4-cp315-cp315-win_arm64.whl", hash = "sha256:f908898d6fa484ce4b6f447ce70ea99b52c503fee419e53cf74d60a16bc9e667"},
+    {file = "greenlet-3.5.4-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:1833637f17d5e7472548a48575c394fe39f1b1890d676d162d86593610f44d8c"},
+    {file = "greenlet-3.5.4-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12cda9122e03341f1cb6b8207a19d7a9d375e52f1b4e9243918375f40fd7b4b9"},
+    {file = "greenlet-3.5.4-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d83ae0e32d14957ab7170785a20f582635c8474deab1bfbb552b17e769a6ce25"},
+    {file = "greenlet-3.5.4-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:123aa379c962ed5fe90a880327e0c3066124ac64ec99e12a238be9fd8eb3db3d"},
+    {file = "greenlet-3.5.4-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f1467de1bb767f75db0aa34c195e3a496d8d1278c796e70c24ce205d3e99cde"},
+    {file = "greenlet-3.5.4-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:adf2244d7f69409925a8f22ed22cc5f93cdfe5c9dc87ff3476be2c2aaae61a05"},
+    {file = "greenlet-3.5.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0fa53040b78b578120eecdc0265e3f1051487cc425d11a2b7c761daadf4feaa8"},
+    {file = "greenlet-3.5.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:60e0bc961d367df506660e9ac0177a76bc6d81305300704b0977d1634f76efe2"},
+    {file = "greenlet-3.5.4-cp315-cp315t-win_amd64.whl", hash = "sha256:f680e549edb3eaf21eea4e7fe101e15ec180c74b7879ab46adc080f22d4015d2"},
+    {file = "greenlet-3.5.4-cp315-cp315t-win_arm64.whl", hash = "sha256:08fc36de8442d5c3e95b044550dbea9bf144d31ec0cc58e36fb241cb6ef6a994"},
+    {file = "greenlet-3.5.4.tar.gz", hash = "sha256:0232ae1de90a8e07867bb127d7a6ba2301e859145489f25cda8a6096dabe1d20"},
 ]
 
 [package.extras]
@@ -718,4 +718,4 @@ standard = ["httptools (>=0.8.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "c71cf881f824327a3313f06f691e6d3e3b7052e5e173615e9a8f0fc680f51ea1"
+content-hash = "cc66de25836e4b8852cdc00c29b91dc96d6434175ef92eebd678527f6a28fd5a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gost-rdpr"
-version = "2.1.0"
+version = "2.2.0"
 description = "The utility provides parsing of domain names into IP addresses, processing of domain lists and their subsequent parsing, processing of individual IP addresses and summarized IP groups. Updates firewall address list and routing table"
 authors = [
     {name = "GregoryGost <info@gregory-gost.ru>"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ homepage = "https://gregory-gost.ru"
 repository = "https://github.com/GregoryGost/gost-rdpr"
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi (>=0.139.2,<0.140.0)",
+    "fastapi (>=0.140.13,<0.141.0)",
     "sqlalchemy (>=2.0.51,<3.0.0)",
     "aiosqlite (>=0.22.1,<0.23.0)",
     "dnspython (>=2.8.0,<3.0.0)",

--- a/routers/ips_router.py
+++ b/routers/ips_router.py
@@ -17,7 +17,10 @@ from models.http.base import ErrorResp, NotFoundResp, NoDataResp, OkResp
 from models.http.ips_req import IpsQueryReq, IpsSearchQueryReq, IpsPostElementReq
 from models.http.ripe_stat_req import RipeStatPrefixCheckReq
 # response models
-from models.http.ips_resp import IpsPayloadResp, IpsElementResp
+from models.http.ips_resp import (
+  IpsPayloadResp,
+  IpsElementResp
+)
 from models.http.ripe_stat_resp import RipeStatPrefixCheckResp
 
 class IpsRouter(BaseRouter):
@@ -88,6 +91,32 @@ class IpsRouter(BaseRouter):
           use_default_gw=query.default_gw
         )
         return JSONResponse(return_data.to_dict(), status.HTTP_200_OK)
+      except Exception as err:
+        return self.errorResp(err)
+
+    @router.post(
+      path='/cleanup/not-allowed',
+      name='Queue cleanup of IP addresses blocked by IP_NOT_ALLOWED',
+      description=(
+        'Starts background cleanup of IP address records matching '
+        'IP_NOT_ALLOWED; deletion is queued without direct database writes'
+      ),
+      response_model=OkResp,
+      status_code=status.HTTP_202_ACCEPTED,
+      responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {'model': ErrorResp}
+      }
+    )
+    async def cleanup_not_allowed_ips(
+      background_tasks: BackgroundTasks
+    ) -> JSONResponse:
+      logger.debug('Call API route: POST /ips/cleanup/not-allowed')
+      try:
+        background_tasks.add_task(db.cleanup_not_allowed_ip_records)
+        return JSONResponse(
+          content=OkResp().to_dict(),
+          status_code=status.HTTP_202_ACCEPTED
+        )
       except Exception as err:
         return self.errorResp(err)
 

--- a/routers/ips_router.py
+++ b/routers/ips_router.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, status, BackgroundTasks, Query, Path, Body
 from fastapi.responses import JSONResponse
+from httpx import HTTPError
 from time import monotonic
 from typing import Annotated, Self, List, Dict
 
 from logger.logger import logger
 from database.db import db
+from client.ripe_stat_client import RipeStatClient, RipeStatClientError
+from utils.utils import get_ip_network_address, get_ip_version
 
 from .base_router import BaseRouter
 
@@ -12,8 +15,10 @@ from .base_router import BaseRouter
 from models.http.base import ErrorResp, NotFoundResp, NoDataResp, OkResp
 # request models
 from models.http.ips_req import IpsQueryReq, IpsSearchQueryReq, IpsPostElementReq
+from models.http.ripe_stat_req import RipeStatPrefixCheckReq
 # response models
 from models.http.ips_resp import IpsPayloadResp, IpsElementResp
+from models.http.ripe_stat_resp import RipeStatPrefixCheckResp
 
 class IpsRouter(BaseRouter):
 
@@ -47,6 +52,8 @@ class IpsRouter(BaseRouter):
       }
     ]
   ]
+
+  __ripe_stat_client: RipeStatClient = RipeStatClient()
 
   def __init__(self: Self) -> None:
     self.router: APIRouter = APIRouter(
@@ -108,6 +115,83 @@ class IpsRouter(BaseRouter):
           use_default_gw=query.default_gw
         )
         return JSONResponse(return_data.to_dict(), status.HTTP_200_OK)
+      except Exception as err:
+        return self.errorResp(err)
+
+    @router.post(
+      path='/ripe/check',
+      name='Check IPv4 prefix in RIPEstat',
+      description='Check an IPv4 address in RIPEstat without saving a record to the database',
+      response_model=RipeStatPrefixCheckResp,
+      responses={
+        status.HTTP_404_NOT_FOUND: {'model': NotFoundResp},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {'model': ErrorResp},
+        status.HTTP_502_BAD_GATEWAY: {'model': ErrorResp},
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {'model': ErrorResp}
+      }
+    )
+    async def check_ip_prefix_in_ripe_stat(
+      data: Annotated[RipeStatPrefixCheckReq, Body()]
+    ) -> JSONResponse:
+      logger.debug('Call API route: POST /ips/ripe/check')
+      try:
+        address: str | None = data.address
+
+        if data.id is not None:
+          ip_record: IpsElementResp | None = await db.get_ip_record_on_id(
+            data.id
+          )
+
+          if ip_record is None:
+            not_found_resp = NotFoundResp(
+              resolution=f"IP address with ID '{data.id}' not found in local db"
+            )
+            return JSONResponse(
+              content=not_found_resp.to_dict(),
+              status_code=status.HTTP_404_NOT_FOUND
+            )
+
+          address = get_ip_network_address(ip_record.addr)
+
+          if get_ip_version(address) != 4:
+            error = ErrorResp(
+              error='Only IPv4 addresses are supported by this check'
+            )
+            return JSONResponse(
+              content=error.to_dict(),
+              status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+            )
+
+          logger.debug(
+            f'IP address found on ID={data.id} for RIPEstat prefix check: '
+            f'{address}'
+          )
+
+        if address is None:
+          raise ValueError('IP address is not defined')
+
+        ripe_result = await self.__ripe_stat_client.get_prefix(address=address)
+        return_data = RipeStatPrefixCheckResp(
+          address=ripe_result.address,
+          prefix=ripe_result.prefix
+        )
+        return JSONResponse(
+          content=return_data.to_dict(),
+          status_code=status.HTTP_200_OK
+        )
+      except (RipeStatClientError, HTTPError) as err:
+        logger.error(
+          f'RIPEstat prefix check failed for {address}: '
+          f'[{err.__class__.__name__}] {err}'
+        )
+        error = ErrorResp(
+          error='RIPEstat prefix check failed',
+          resolution=str(err)
+        )
+        return JSONResponse(
+          content=error.to_dict(),
+          status_code=status.HTTP_502_BAD_GATEWAY
+        )
       except Exception as err:
         return self.errorResp(err)
 

--- a/routers/ips_router.py
+++ b/routers/ips_router.py
@@ -6,6 +6,7 @@ from typing import Annotated, Self, List, Dict
 
 from logger.logger import logger
 from database.db import db
+from cache.cache import ripe_stat_cache
 from client.ripe_stat_client import RipeStatClient, RipeStatClientError
 from utils.utils import get_ip_network_address, get_ip_version
 
@@ -117,6 +118,26 @@ class IpsRouter(BaseRouter):
           content=OkResp().to_dict(),
           status_code=status.HTTP_202_ACCEPTED
         )
+      except Exception as err:
+        return self.errorResp(err)
+
+    @router.post(
+      path='/ripe/cache/clear',
+      name='Clear RIPEstat prefix cache',
+      description=(
+        'Clears only the in-memory RIPEstat prefix cache without changing '
+        'database records'
+      ),
+      response_model=OkResp,
+      responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {'model': ErrorResp}
+      }
+    )
+    async def clear_ripe_stat_cache() -> JSONResponse:
+      logger.debug('Call API route: POST /ips/ripe/cache/clear')
+      try:
+        await ripe_stat_cache.clear()
+        return JSONResponse(OkResp().to_dict(), status.HTTP_200_OK)
       except Exception as err:
         return self.errorResp(err)
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -32,6 +32,13 @@ def get_ip_without_prefix(ip_address: str) -> str:
   except Exception as err:
     raise err
 
+def get_ip_network_address(ip_address: str) -> str:
+  try:
+    network = ip_network(ip_address, strict=False)
+    return str(network.network_address)
+  except Exception as err:
+    raise err
+
 def calculate_checksum(file_path: Path) -> str:
   '''Calculate checksum for file'''
   with open(file_path, 'r', encoding='utf-8') as f:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -18,9 +18,11 @@ def check_ip_allow(ip: str) -> bool:
   Allow = True  
   Block = False
   '''
-  if ip in settings.ip_not_allowed_list:
-    return False
-  return True
+  candidate_network = ip_network(ip, strict=False)
+  return not any(
+    candidate_network.overlaps(blocked_network)
+    for blocked_network in settings.ip_not_allowed_networks
+  )
 
 def get_ip_without_prefix(ip_address: str) -> str:
   try:


### PR DESCRIPTION
### RIPEstat и резолвинг доменов

- Добавлены конфигурация, HTTP-клиент и DTO для получения сетевого префикса из RIPEstat.
- Резолвинг доменов сохраняет подтверждённый CIDR для публичных IPv4-адресов, оканчивающихся на `.0`.
- Повторный резолвинг заменяет `/32` на CIDR, сохраняет существующий CIDR при недоступности RIPEstat и удаляет устаревшие записи.
- Добавлен endpoint `POST /ips/ripe/check` для проверки IP-адреса или сохранённой записи по ID без изменений в БД.
- Добавлен endpoint `POST /ips/ripe/cache/clear` для очистки in-memory кеша RIPEstat.

### Фильтрация IP-адресов

- `IP_NOT_ALLOWED` интерпретируется как список CIDR-сетей.
- Значение по умолчанию дополнено приватными, служебными, тестовыми, multicast и резервными диапазонами.
- Добавлен фоновый endpoint `POST /ips/cleanup/not-allowed` для очистки существующих запрещённых адресов через очередь БД с действием `IPS_DELETE_ID`.

### Кеширование и конфигурация

- Добавлен ограниченный in-memory кеш `cashews` для ответов RIPEstat.
- Добавлены отдельные TTL для найденного и отсутствующего префикса, ограничение размера кеша и per-IP блокировка.
- Ошибки RIPEstat исключены из кеширования.
- README дополнен актуальными переменными окружения.
- Обновлены FastAPI и lock-файл зависимостей.