### PR TITLE
Атомарные статусы фоновых jobs и оптимизация RIPE-кеша

### DIFF
--- a/cache/cache.py
+++ b/cache/cache.py
@@ -1,17 +1,9 @@
 from cashews import cache
 from cashews.backends.interface import Backend
-from enum import StrEnum
 from typing import Any, Self
 
 from logger.logger import logger
 from config.config import settings
-
-class Jobs(StrEnum):
-  LISTS_LOAD            = 'lists_load'
-  DOMAINS_RESOLVE   = 'domains_resolve' # for check job
-  DOMAINS_RESOLVE_NEW   = 'domains_resolve_new'
-  DOMAINS_RESOLVE_STALE = 'domains_resolve_stale'
-  ROS_UPDATE            = 'ros_update'
 
 class Cache():
   '''
@@ -55,7 +47,6 @@ class Cache():
     return self.cache.lock(key=key, expire=expire, wait=wait)
 
 try:
-  jobs_cache: Cache = Cache('jobs_cache')
   ripe_stat_cache: Cache = Cache(
     'ripe_stat_cache',
     size=settings.ripe_stat_cache_size

--- a/cache/cache.py
+++ b/cache/cache.py
@@ -19,29 +19,14 @@ class Cache():
     self.cache: Backend = cache.setup(mem, prefix=prefix)
     logger.debug(f'{self.__class__.__name__} init')
 
-  async def update(self, key: str, value: Any, expire: float | None = None) -> None:
-    '''
-    Update data in cache or add it if it does not exist.
-    VALUE: need to be DICTIONARY or SERIALIZEABLE string
-    '''
-    exists: bool = await self.cache.exists(key)
-    if exists:
-      await self.cache.delete(key=key)
-      await self.cache.set(key=key, value=value, expire=expire)
-    else:
-      await self.cache.set(key=key, value=value, expire=expire)
-
   async def get(self: Self, key: str) -> Any | None:
     return await self.cache.get(key)
-  
-  async def exists(self: Self, key: str) -> bool:
-    return await self.cache.exists(key=key)
-  
+
   async def clear(self: Self) -> None:
     await self.cache.clear()
 
   async def set(self: Self, key: str, value: Any, expire: float | None = None) -> None:
-    await self.update(key=key, value=value, expire=expire)
+    await self.cache.set(key=key, value=value, expire=expire)
 
   def lock(self: Self, key: str, expire: float, wait: bool = True) -> Any:
     return self.cache.lock(key=key, expire=expire, wait=wait)

--- a/client/domains_resolving_client.py
+++ b/client/domains_resolving_client.py
@@ -33,7 +33,7 @@ from typing import Self, List, Tuple, Dict, Literal
 
 from logger.logger import logger
 from config.config import settings
-from cache.cache import jobs_cache, Jobs
+from jobs.job_registry import job_registry, Jobs
 from database.db import db
 from client.http_base_client import HttpClient
 from client.ripe_stat_client import RipeStatClient, RipeStatClientError
@@ -508,7 +508,6 @@ class DomainsResolver:
   async def domains_resolve(self: Self, job_mode: Jobs) -> None:
     logger.info(f'Domains resolve mode={job_mode} - START')
     try:
-      await jobs_cache.set(job_mode, True)
       #
       match job_mode:
         case Jobs.DOMAINS_RESOLVE_NEW:
@@ -539,8 +538,7 @@ class DomainsResolver:
     except Exception as err:
       logger.error(f'Try Domains resolve mode={job_mode} failed [{err.__class__.__name__}] : {err}', exc_info=True)
     finally:
-      await jobs_cache.set(job_mode, False)
-      await jobs_cache.set(Jobs.DOMAINS_RESOLVE, False)
+      await job_registry.finish(Jobs.DOMAINS_RESOLVE)
 
   async def resolve_once(
     self: Self,

--- a/client/ripe_stat_client.py
+++ b/client/ripe_stat_client.py
@@ -98,10 +98,10 @@ class RipeStatClient:
     address: str,
     cache_key: str
   ) -> RipeStatAddressPrefixDto | None:
-    if not await ripe_stat_cache.exists(cache_key):
-      return None
-
     cached_prefix = await ripe_stat_cache.get(cache_key)
+
+    if cached_prefix is None:
+      return None
 
     if not isinstance(cached_prefix, str):
       logger.warning(

--- a/client/ros_updater_client.py
+++ b/client/ros_updater_client.py
@@ -9,7 +9,7 @@ from .http_base_client import HttpClient
 from logger.logger import logger
 from config.config import settings
 from database.db import db
-from cache.cache import jobs_cache, Jobs
+from jobs.job_registry import job_registry, Jobs
 
 from models.dto.ip_record_dto import IpRecordDto
 from models.dto.ros_config_dto import RosConfigDto, RosAction
@@ -571,4 +571,4 @@ class RosClient:
     except Exception as err:
       logger.error(f'Update ROS configs failed: [{err.__class__.__name__}] : {err}', exc_info=True)
     finally:
-      await jobs_cache.set(Jobs.ROS_UPDATE, False)
+      await job_registry.finish(Jobs.ROS_UPDATE)

--- a/database/db.py
+++ b/database/db.py
@@ -86,7 +86,7 @@ from models.dto.ip_record_dto import IpRecordDto
 from models.dto.ros_config_dto import RosConfigDto
 from models.dto.migrations_dto import MigrationsDto
 
-from cache.cache import jobs_cache, Jobs
+from jobs.job_registry import job_registry, Jobs
 
 class DataBase:
   '''
@@ -1479,8 +1479,9 @@ class DataBase:
 
   async def lists_load(self: Self, forced: bool) -> None:
     logger.info(f'Lists load - START {forced=}')
+    db_session: AsyncSession | None = None
     try:
-      db_session: AsyncSession = await self.__read_connect()
+      db_session = await self.__read_connect()
       domains_lists_total: int = await DomainsListsDbo.get_total(db_session=db_session)
       ips_lists_total: int = await IpsListsDbo.get_total(db_session=db_session)
       if domains_lists_total > 0:
@@ -1551,10 +1552,14 @@ class DataBase:
           await self.update_ips_lists(ips_lists=active_ips_lists)
     except Exception as err:
       logger.error(f'Try Lists load failed : {err}', exc_info=True)
-      await db_session.rollback()
+      if db_session is not None:
+        await db_session.rollback()
     finally:
-      await db_session.close()
-      await jobs_cache.set(Jobs.LISTS_LOAD, False)
+      try:
+        if db_session is not None:
+          await db_session.close()
+      finally:
+        await job_registry.finish(Jobs.LISTS_LOAD)
 
   # Stats
 

--- a/jobs/job_registry.py
+++ b/jobs/job_registry.py
@@ -1,0 +1,57 @@
+from asyncio import Lock
+from enum import StrEnum
+from typing import Self
+
+from logger.logger import logger
+
+
+class Jobs(StrEnum):
+  LISTS_LOAD = 'lists_load'
+  DOMAINS_RESOLVE = 'domains_resolve'
+  DOMAINS_RESOLVE_NEW = 'domains_resolve_new'
+  DOMAINS_RESOLVE_STALE = 'domains_resolve_stale'
+  ROS_UPDATE = 'ros_update'
+
+
+class JobRegistry:
+  '''
+  Stores active background jobs in the current application process.
+  '''
+
+  def __init__(self: Self) -> None:
+    self.__active_jobs: set[Jobs] = set()
+    self.__lock: Lock = Lock()
+
+  async def try_start(self: Self, job: Jobs) -> bool:
+    '''
+    Atomically reserves a job. Returns False when the job is already active.
+    '''
+    async with self.__lock:
+      if job in self.__active_jobs:
+        return False
+      self.__active_jobs.add(job)
+      logger.debug(f'Job {job} started')
+      return True
+
+  async def finish(self: Self, job: Jobs) -> None:
+    '''
+    Marks a job as inactive. It is safe to call more than once.
+    '''
+    async with self.__lock:
+      self.__active_jobs.discard(job)
+      logger.debug(f'Job {job} finished')
+
+  async def is_active(self: Self, job: Jobs) -> bool:
+    async with self.__lock:
+      return job in self.__active_jobs
+
+  async def reset(self: Self) -> None:
+    '''
+    Clears all in-memory statuses before application startup.
+    '''
+    async with self.__lock:
+      self.__active_jobs.clear()
+      logger.debug(f'{self.__class__.__name__} reset')
+
+
+job_registry: JobRegistry = JobRegistry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gost-rdpr"
-version = "2.2.0"
+version = "2.2.1"
 description = "The utility provides parsing of domain names into IP addresses, processing of domain lists and their subsequent parsing, processing of individual IP addresses and summarized IP groups. Updates firewall address list and routing table"
 authors = [
     {name = "GregoryGost <info@gregory-gost.ru>"}

--- a/routers/commands_router.py
+++ b/routers/commands_router.py
@@ -5,7 +5,7 @@ from typing import Annotated, Self
 
 from logger.logger import logger
 from database.db import db
-from cache.cache import jobs_cache, Jobs
+from jobs.job_registry import job_registry, Jobs
 from client.domains_resolving_client import DomainsResolver
 from client.ros_updater_client import RosClient
 
@@ -46,10 +46,12 @@ class CommandsRouter(BaseRouter):
     ) -> JSONResponse:
       logger.debug(f'Call API route: POST /commands/lists/load')
       try:
-        job_status: bool | None = await jobs_cache.get(Jobs.LISTS_LOAD)
-        if job_status != True:
-          await jobs_cache.set(Jobs.LISTS_LOAD, True)
-          background_tasks.add_task(db.lists_load, query.forced)
+        if await job_registry.try_start(Jobs.LISTS_LOAD):
+          try:
+            background_tasks.add_task(db.lists_load, query.forced)
+          except Exception:
+            await job_registry.finish(Jobs.LISTS_LOAD)
+            raise
         else:
           return JSONResponse(
             OkResp(result=f'Job {Jobs.LISTS_LOAD} is Run').to_dict(),
@@ -72,13 +74,15 @@ class CommandsRouter(BaseRouter):
     async def domains_resolve_new_command(background_tasks: BackgroundTasks) -> JSONResponse:
       logger.debug(f'Call API route: POST /commands/domains/resolve/new')
       try:
-        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE)
-        if job_status != True:
-          await jobs_cache.set(Jobs.DOMAINS_RESOLVE, True)
-          background_tasks.add_task(
-            self.domains_resolver.domains_resolve,
-            Jobs.DOMAINS_RESOLVE_NEW
-          )
+        if await job_registry.try_start(Jobs.DOMAINS_RESOLVE):
+          try:
+            background_tasks.add_task(
+              self.domains_resolver.domains_resolve,
+              Jobs.DOMAINS_RESOLVE_NEW
+            )
+          except Exception:
+            await job_registry.finish(Jobs.DOMAINS_RESOLVE)
+            raise
         else:
           return JSONResponse(
             OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE}] is now active').to_dict(),
@@ -100,13 +104,15 @@ class CommandsRouter(BaseRouter):
     async def domains_resolve_stale_command(background_tasks: BackgroundTasks) -> JSONResponse:
       logger.debug(f'Call API route: POST /commands/domains/resolve/stale')
       try:
-        job_status: bool | None = await jobs_cache.get(Jobs.DOMAINS_RESOLVE)
-        if job_status != True:
-          await jobs_cache.set(Jobs.DOMAINS_RESOLVE, True)
-          background_tasks.add_task(
-            self.domains_resolver.domains_resolve,
-            Jobs.DOMAINS_RESOLVE_STALE
-          )
+        if await job_registry.try_start(Jobs.DOMAINS_RESOLVE):
+          try:
+            background_tasks.add_task(
+              self.domains_resolver.domains_resolve,
+              Jobs.DOMAINS_RESOLVE_STALE
+            )
+          except Exception:
+            await job_registry.finish(Jobs.DOMAINS_RESOLVE)
+            raise
         else:
           return JSONResponse(
             OkResp(result=f'Job [{Jobs.DOMAINS_RESOLVE}] is now active').to_dict(),
@@ -138,10 +144,12 @@ class CommandsRouter(BaseRouter):
             ).to_dict(),
             status.HTTP_400_BAD_REQUEST
           )
-        job_status: bool | None = await jobs_cache.get(Jobs.ROS_UPDATE)
-        if job_status != True:
-          await jobs_cache.set(Jobs.ROS_UPDATE, True)
-          background_tasks.add_task(self.__ros_client.update, query.type)
+        if await job_registry.try_start(Jobs.ROS_UPDATE):
+          try:
+            background_tasks.add_task(self.__ros_client.update, query.type)
+          except Exception:
+            await job_registry.finish(Jobs.ROS_UPDATE)
+            raise
         else:
           return JSONResponse(
             OkResp(result=f'Job [{Jobs.ROS_UPDATE}] is now active').to_dict(),

--- a/routers/ips_router.py
+++ b/routers/ips_router.py
@@ -175,7 +175,7 @@ class IpsRouter(BaseRouter):
       response_model=RipeStatPrefixCheckResp,
       responses={
         status.HTTP_404_NOT_FOUND: {'model': NotFoundResp},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {'model': ErrorResp},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {'model': ErrorResp},
         status.HTTP_502_BAD_GATEWAY: {'model': ErrorResp},
         status.HTTP_500_INTERNAL_SERVER_ERROR: {'model': ErrorResp}
       }
@@ -209,7 +209,7 @@ class IpsRouter(BaseRouter):
             )
             return JSONResponse(
               content=error.to_dict(),
-              status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+              status_code=status.HTTP_422_UNPROCESSABLE_CONTENT
             )
 
           logger.debug(

--- a/server/server.py
+++ b/server/server.py
@@ -102,7 +102,7 @@ class AppServer:
         logger.error(
           f'RequestValidationError={str(exception)} :\n URL={unquote(request.url.__str__())} :\n bodyStr={bodyStr} :\n args={args}'
         )
-        return JSONResponse(content=jsonable_encoder(exception.errors()), status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
+        return JSONResponse(content=jsonable_encoder(exception.errors()), status_code=status.HTTP_422_UNPROCESSABLE_CONTENT)
       except Exception as err:
         logger.error(err)
         return JSONResponse(

--- a/server/server.py
+++ b/server/server.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from config.config import settings
 from logger.logger import logger
 from database.db import db
-from cache.cache import jobs_cache
+from jobs.job_registry import job_registry
 from metrics.metrics import PrometheusMiddleware
 from client.http_base_client import HttpClient
 
@@ -27,7 +27,7 @@ from routers.domains_router import DomainsRouter
 from routers.ips_lists_router import IpsListsRouter
 from routers.ips_router import IpsRouter
 from routers.ros_configs_router import RosConfigsRouter
-from routers.commands_router import CommandsRouter, Jobs
+from routers.commands_router import CommandsRouter
 from routers.statistics_router import StatisticsRouter
 
 from models.http.base import ErrorResp
@@ -67,12 +67,7 @@ class AppServer:
   @asynccontextmanager
   async def __lifespan(self: Self, app: FastAPI) -> AsyncGenerator[None, Any]:
     # first RUN BEFORE start FastAPI
-    # Cache init
-    await jobs_cache.set(key=Jobs.LISTS_LOAD, value=False)
-    await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE, value=False)
-    await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE_NEW, value=False)
-    await jobs_cache.set(key=Jobs.DOMAINS_RESOLVE_STALE, value=False)
-    await jobs_cache.set(key=Jobs.ROS_UPDATE, value=False)
+    await job_registry.reset()
     # Init DB
     await db.setup()
     # Domains resolver init


### PR DESCRIPTION
## Изменения

- Добавлен in-memory `JobRegistry` с атомарным резервированием статусов через `asyncio.Lock`.
- Переведены команды загрузки списков, резолвинга доменов и синхронизации RouterOS с `jobs_cache` на реестр.
- Сохранена взаимная блокировка режимов резолвинга `new` и `stale`.
- Гарантировано освобождение статусов jobs в `finally`, включая ошибку открытия DB-сессии.
- Добавлен сброс реестра при старте приложения.
- Удалён `jobs_cache` из обёртки `cashews`.
- Упрощена запись в RIPE-кеш до одной операции `set`.
- Сокращено чтение RIPE-кеша до одного `get` с сохранением отрицательных результатов.
- Заменены устаревшие константы `HTTP_422_UNPROCESSABLE_ENTITY`.
- Обновлена версия приложения до `2.2.1`.